### PR TITLE
broker: Use better wording for the qrcode button

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -316,11 +316,11 @@ func (b *Broker) generateUILayout(session *sessionInfo, authModeID string) (map[
 		uiLayout = map[string]string{
 			"type": "qrcode",
 			"label": fmt.Sprintf(
-				"Scan the QR code or access %q and use the provided code",
+				"Scan the QR code or access %q and use the provided login code",
 				response.VerificationURI,
 			),
 			"wait":    "true",
-			"button":  "regenerate QR code",
+			"button":  "Request new login code",
 			"content": response.VerificationURI,
 			"code":    response.UserCode,
 		}

--- a/internal/broker/testdata/TestSelectAuthenticationMode/golden/successfully_select_device_auth
+++ b/internal/broker/testdata/TestSelectAuthenticationMode/golden/successfully_select_device_auth
@@ -1,6 +1,6 @@
-button: regenerate QR code
+button: Request new login code
 code: user_code
 content: https://verification_uri.com
-label: Scan the QR code or access "https://verification_uri.com" and use the provided code
+label: Scan the QR code or access "https://verification_uri.com" and use the provided login code
 type: qrcode
 wait: "true"


### PR DESCRIPTION
The button is selecting the authentication again, requesting a new login code, not the qrcode itself.

So improve wording here a bit

UDENG-3416