### PR TITLE
maint: Bump Go to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers
 
 go 1.22.0
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers/tools
 
 go 1.22.0
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 require github.com/golangci/golangci-lint v1.59.1
 


### PR DESCRIPTION
Fixes Vulnerability: GO-2024-2963
    Denial of service due to improper 100-continue handling in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2963
  Standard library
    Found in: net/http@go1.22.4
    Fixed in: net/http@go1.22.5