### PR TITLE
feat: Implement UserPreCheck

### DIFF
--- a/internal/dbusservice/consts.go
+++ b/internal/dbusservice/consts.go
@@ -17,4 +17,6 @@ const (
 	clientIDKey = "client_id"
 	// homeDirKey is the key in the config file for the home directory prefix.
 	homeDirKey = "home_base_dir"
+	// SSHSuffixKey is the key in the config file for the SSH allowed suffixes.
+	sshSuffixesKey = "ssh_allowed_suffixes"
 )

--- a/internal/dbusservice/methods.go
+++ b/internal/dbusservice/methods.go
@@ -54,3 +54,12 @@ func (s *Service) CancelIsAuthenticated(sessionID string) (dbusErr *dbus.Error) 
 	s.broker.CancelIsAuthenticated(sessionID)
 	return nil
 }
+
+// UserPreCheck is the method through which the broker and the daemon will communicate once dbusInterface.UserPreCheck is called.
+func (s *Service) UserPreCheck(username string) (dbusErr *dbus.Error) {
+	err := s.broker.UserPreCheck(username)
+	if err != nil {
+		return dbus.MakeFailedError(err)
+	}
+	return nil
+}

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -21,4 +21,8 @@ client_id = {client_id}
 # The user home directory will be created in the format of {home_base_dir}/{username}
 # home_base_dir = /home
 
+# The username suffixes that are allowed to login via ssh without existing previously in the system.
+# The suffixes must be separated by commas.
+# ssh_allowed_suffixes = @example.com,@anotherexample.com
+
 EOF


### PR DESCRIPTION
This adds the implementation for the UserPreCheck method on the broker. Without it, users would never be able to authenticate through SSH without first authenticating locally in the machine, which is not ideal.

UDENG-3415