### PR TITLE
refactor: Fail authentication sooner if failed to fetch user info

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -368,7 +368,8 @@ func TestIsAuthenticated(t *testing.T) {
 				"token": (&oauth2.Token{}).WithExtra(map[string]interface{}{"id_token": "invalid"}),
 			},
 		},
-		"Error when selected username does not match the provider one": {username: "not-matching", firstChallenge: "-", wantSecondCall: true},
+		// This test case also tests that errors with double quotes are marshaled to JSON correctly.
+		"Error when selected username does not match the provider one": {username: "not-matching", firstChallenge: "-"},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_selected_username_does_not_match_the_provider_one/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_selected_username_does_not_match_the_provider_one/first_call
@@ -1,3 +1,3 @@
-access: next
-data: '{}'
+access: denied
+data: '{"message":"could not get user info: could not fetch user info: returned user \"test-user@email.com\" does not match the selected one \"not-matching\""}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_selected_username_does_not_match_the_provider_one/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_selected_username_does_not_match_the_provider_one/second_call
@@ -1,3 +1,0 @@
-access: denied
-data: '{"message":"could not get user info: could not fetch user info: returned user \"test-user@email.com\" does not match the selected one \"not-matching\""}'
-err: <nil>


### PR DESCRIPTION
When first authenticating with QRCode, the user would have to also create its local password before knowing if the authentication failed. Now, the user info is fetched before the password creation prompt, and authentication will fail before asking for password creation. 

UDENG-3414