### PR TITLE
fix(tests): Add hidden flag to run daemon with custom bus name

### DIFF
--- a/cmd/authd-oidc/daemon/daemon_test.go
+++ b/cmd/authd-oidc/daemon/daemon_test.go
@@ -378,12 +378,12 @@ func captureStdout(t *testing.T) func() string {
 
 func TestMain(m *testing.M) {
 	// Start system bus mock.
-	cleanup, err := testutils.StartSystemBusMock()
+	busCleanup, err := testutils.StartSystemBusMock()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
-	defer cleanup()
+	defer busCleanup()
 
 	// Start provider mock
 	providerServer, cleanup := testutils.StartMockProvider("")

--- a/cmd/authd-oidc/daemon/export_test.go
+++ b/cmd/authd-oidc/daemon/export_test.go
@@ -20,7 +20,7 @@ func NewForTests(t *testing.T, conf *DaemonConfig, providerURL string, args ...s
 	t.Helper()
 
 	p := GenerateTestConfig(t, conf, providerURL)
-	argsWithConf := []string{"--config", p}
+	argsWithConf := []string{"--execbusname", "com.ubuntu.authd." + t.Name(), "--config", p}
 	argsWithConf = append(argsWithConf, args...)
 
 	a := New(t.Name())
@@ -51,12 +51,6 @@ func GenerateTestConfig(t *testing.T, origConf *daemonConfig, providerURL string
 	}
 
 	brokerCfg := fmt.Sprintf(`
-[authd]
-name = %[1]s
-brand_icon = broker_icon.png
-dbus_name = com.ubuntu.authd.%[1]s
-dbus_object = /com/ubuntu/authd/%[1]s
-
 [oidc]
 issuer = %[2]s
 client_id = client_id


### PR DESCRIPTION
Changing the bus service to use a default bus name broke the parallel tests as we were trying to export the same bus multiple times. Now, each test instance will export its own bus for the daemon tests to avoid conflicts.

UDENG-3553