### PR TITLE
Fix autoupdate brokers specific branch when there is no conflict

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -86,7 +86,7 @@ jobs:
           if: ${{ steps.merge.outputs.has_conflicts == 'false' }}
           run: |
             set -eux
-            git push origin ${{ matrix.branch_name }}
+            git push origin :${{ matrix.branch_name }}
 
             # Potentially existing PR with conflicts is not valid anymore: we just automerged.
             git push origin --delete update-${{ matrix.branch_name }} || true


### PR DESCRIPTION
We were not pushing the local branch but a local branch with the same name.

UDENG-3664