### PR TITLE
Really fix automerge

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 concurrency: auto-update-broker-variants
 
 permissions:

--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -86,10 +86,7 @@ jobs:
           if: ${{ steps.merge.outputs.has_conflicts == 'false' }}
           run: |
             set -eux
-            git push origin :${{ matrix.branch_name }}
-
-            # Potentially existing PR with conflicts is not valid anymore: we just automerged.
-            git push origin --delete update-${{ matrix.branch_name }} || true
+            git push origin update-${{ matrix.branch_name }}:${{ matrix.branch_name }}
 
         - name: Restore and prepare branch
           if: ${{ steps.merge.outputs.has_conflicts == 'true' }}


### PR DESCRIPTION
We need to specify the original branch and not only the destination, otherwise the branch is removed.
We already mark the original branch to be autodeleted on the PR, no need to force it too.
Allow manual workflow triggers.