### PR TITLE
Only include build-time when you import the package

### DIFF
--- a/internal/providers/microsoft_entra_id/microsoft-entra-id.go
+++ b/internal/providers/microsoft_entra_id/microsoft-entra-id.go
@@ -1,5 +1,3 @@
-//go:build withmsentraid
-
 // Package microsoft_entra_id is the Microsoft Entra ID specific extension.
 package microsoft_entra_id
 

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -21,21 +21,21 @@ import (
 
 const localGroupPrefix = "linux-"
 
-// MSEntraIDProvider is the Microsoft Entra ID provider implementation.
-type MSEntraIDProvider struct{}
+// Provider is the Microsoft Entra ID provider implementation.
+type Provider struct{}
 
 // AdditionalScopes returns the generic scopes required by the EntraID provider.
-func (p MSEntraIDProvider) AdditionalScopes() []string {
+func (p Provider) AdditionalScopes() []string {
 	return []string{oidc.ScopeOfflineAccess}
 }
 
 // AuthOptions returns the generic auth options required by the EntraID provider.
-func (p MSEntraIDProvider) AuthOptions() []oauth2.AuthCodeOption {
+func (p Provider) AuthOptions() []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 
 // GetGroups access the Microsoft Graph API to get the groups the user is a member of.
-func (p MSEntraIDProvider) GetGroups(token *oauth2.Token) ([]group.Info, error) {
+func (p Provider) GetGroups(token *oauth2.Token) ([]group.Info, error) {
 	cred := azureTokenCredential{token: token}
 	auth, err := msauth.NewAzureIdentityAuthenticationProvider(cred)
 	if err != nil {
@@ -114,7 +114,7 @@ func (p MSEntraIDProvider) GetGroups(token *oauth2.Token) ([]group.Info, error) 
 // CurrentAuthenticationModesOffered returns the generic authentication modes supported by the provider.
 //
 // Token validity is not considered, only the presence of a token.
-func (p MSEntraIDProvider) CurrentAuthenticationModesOffered(
+func (p Provider) CurrentAuthenticationModesOffered(
 	sessionMode string,
 	supportedAuthModes map[string]string,
 	tokenExists bool,

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -1,5 +1,5 @@
-// Package microsoft_entra_id is the Microsoft Entra ID specific extension.
-package microsoft_entra_id
+// Package msentraid is the Microsoft Entra ID specific extension.
+package msentraid
 
 import (
 	"context"

--- a/internal/providers/withmsentraid.go
+++ b/internal/providers/withmsentraid.go
@@ -8,5 +8,5 @@ import (
 
 // CurrentProviderInfo returns a Microsoft Entra ID provider implementation.
 func CurrentProviderInfo() ProviderInfoer {
-	return msentraid.MSEntraIDProvider{}
+	return msentraid.Provider{}
 }

--- a/internal/providers/withmsentraid.go
+++ b/internal/providers/withmsentraid.go
@@ -3,10 +3,10 @@
 package providers
 
 import (
-	"github.com/ubuntu/authd-oidc-brokers/internal/providers/microsoft_entra_id"
+	"github.com/ubuntu/authd-oidc-brokers/internal/providers/msentraid"
 )
 
 // CurrentProviderInfo returns a Microsoft Entra ID provider implementation.
 func CurrentProviderInfo() ProviderInfoer {
-	return microsoft_entra_id.MSEntraIDProvider{}
+	return msentraid.MSEntraIDProvider{}
 }


### PR DESCRIPTION
Let’s trust ourself to import it when needed, that way, we have the linter running when it’s needed.

Now, only withmsentraid.go have the build-tag to import it.