### PR TITLE
Include transitive groups membership

### DIFF
--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -65,7 +65,7 @@ func (p Provider) GetGroups(token *oauth2.Token) ([]group.Info, error) {
 		return nil, fmt.Errorf("could not access user's groups: %v", err)
 	}
 
-	m, err := client.Me().MemberOf().Get(context.Background(), nil)
+	m, err := client.Me().TransitiveMemberOf().Get(context.Background(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When Azure AD group membership are organized in a tree, it’s expected that transitive inclusion to be taken into account. Change the API, which requires the same permission to follow this. The list of groups is then flatten when going over the API, resulting in no other code change needed.