### PR TITLE
feat: Move fetchUserInfo logic to the providers pkg

### DIFF
--- a/internal/broker/authresponses.go
+++ b/internal/broker/authresponses.go
@@ -1,12 +1,14 @@
 package broker
 
+import "github.com/ubuntu/authd-oidc-brokers/internal/providers/info"
+
 type isAuthenticatedDataResponse interface {
 	isAuthenticatedDataResponse()
 }
 
 // userInfoMessage represents the user information message that is returned to authd.
 type userInfoMessage struct {
-	UserInfo userInfo `json:"userinfo"`
+	UserInfo info.User `json:"userinfo"`
 }
 
 func (userInfoMessage) isAuthenticatedDataResponse() {}

--- a/internal/broker/export_test.go
+++ b/internal/broker/export_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/ubuntu/authd-oidc-brokers/internal/providers/info"
 )
 
 // TokenPathForSession returns the path to the token file for the given session.
@@ -94,17 +96,15 @@ func writeTrashToken(path, challenge string) error {
 }
 
 // FetchUserInfo exposes the broker's fetchUserInfo method for tests.
-//
-//nolint:revive // This is a test helper and the returned userInfo will be marshaled for golden files.
-func (b *Broker) FetchUserInfo(sessionID string, cachedInfo *authCachedInfo) (userInfo, error) {
+func (b *Broker) FetchUserInfo(sessionID string, cachedInfo *authCachedInfo) (info.User, error) {
 	s, err := b.getSession(sessionID)
 	if err != nil {
-		return userInfo{}, err
+		return info.User{}, err
 	}
 
 	uInfo, err := b.fetchUserInfo(context.TODO(), &s, cachedInfo)
 	if err != nil {
-		return userInfo{}, err
+		return info.User{}, err
 	}
 
 	return uInfo, err
@@ -118,9 +118,6 @@ func (b *Broker) IsOffline(sessionID string) (bool, error) {
 	}
 	return session.isOffline, nil
 }
-
-// UserInfo exposes the private userInfo for tests.
-type UserInfo = userInfo
 
 // MaxRequestDuration exposes the broker's maxRequestDuration for tests.
 const MaxRequestDuration = maxRequestDuration

--- a/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_ignoring_different_casing_in_name
+++ b/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_ignoring_different_casing_in_name
@@ -1,8 +1,8 @@
-name: test-user@email.com
+name: TEST-USER@EMAIL.COM
 uuid: saved-user-id
-home: /home/test-user@email.com
+home: /home/userInfoTests/TEST-USER@EMAIL.COM
 shell: /usr/bin/bash
-gecos: test-user@email.com
+gecos: TEST-USER@EMAIL.COM
 groups:
     - name: remote-group
       ugid: "12345"

--- a/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_with_groups
+++ b/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_with_groups
@@ -2,7 +2,7 @@ name: test-user@email.com
 uuid: saved-user-id
 home: /home/userInfoTests/test-user@email.com
 shell: /usr/bin/bash
-gecos: saved-user
+gecos: test-user@email.com
 groups:
     - name: remote-group
       ugid: "12345"

--- a/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_without_groups
+++ b/internal/broker/testdata/TestFetchUserInfo/golden/successfully_fetch_user_info_without_groups
@@ -2,5 +2,5 @@ name: test-user@email.com
 uuid: saved-user-id
 home: /home/userInfoTests/test-user@email.com
 shell: /usr/bin/bash
-gecos: saved-user
+gecos: test-user@email.com
 groups: []

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_refreshes_expired_token/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_refreshes_expired_token/first_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_server_is_unreachable/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_server_is_unreachable/first_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"saved-user","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_token_is_expired_and_server_is_unreachable/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_password_still_allowed_if_token_is_expired_and_server_is_unreachable/first_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"saved-user","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_qrcode_reacquires_token/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_with_qrcode_reacquires_token/second_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"saved-user","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_qrcode+newpassword/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_qrcode+newpassword/second_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/providers/group/info.go
+++ b/internal/providers/group/info.go
@@ -1,8 +1,0 @@
-// Package group defines group-related types used by the broker.
-package group
-
-// Info represents the group information that is fetched by the broker.
-type Info struct {
-	Name string `json:"name"`
-	UGID string `json:"ugid"`
-}

--- a/internal/providers/info/info.go
+++ b/internal/providers/info/info.go
@@ -1,0 +1,44 @@
+// Package info defines types used by the broker.
+package info
+
+// Group represents the group information that is fetched by the broker.
+type Group struct {
+	Name string `json:"name"`
+	UGID string `json:"ugid"`
+}
+
+// User represents the user information obtained from the provider.
+type User struct {
+	Name   string  `json:"name"`
+	UUID   string  `json:"uuid"`
+	Home   string  `json:"dir"`
+	Shell  string  `json:"shell"`
+	Gecos  string  `json:"gecos"`
+	Groups []Group `json:"groups"`
+}
+
+// NewUser creates a new user with the specified values.
+//
+// It fills the defaults for Shell and Gecos if they are empty.
+func NewUser(name, home, uuid, shell, gecos string, groups []Group) User {
+	u := User{
+		Name:   name,
+		Home:   home,
+		UUID:   uuid,
+		Shell:  shell,
+		Gecos:  gecos,
+		Groups: groups,
+	}
+
+	if u.Home == "" {
+		u.Home = u.Name
+	}
+	if u.Shell == "" {
+		u.Shell = "/usr/bin/bash"
+	}
+	if u.Gecos == "" {
+		u.Gecos = u.Name
+	}
+
+	return u
+}

--- a/internal/providers/info/info_test.go
+++ b/internal/providers/info/info_test.go
@@ -1,0 +1,82 @@
+package info_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd-oidc-brokers/internal/providers/info"
+)
+
+func TestNewUser(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		name   string
+		home   string
+		uuid   string
+		shell  string
+		gecos  string
+		groups []info.Group
+	}{
+		"Create a new user": {
+			name:   "test-user",
+			home:   "/home/test-user",
+			uuid:   "some-uuid",
+			shell:  "/usr/bin/zsh",
+			gecos:  "Test User",
+			groups: []info.Group{{Name: "test-group", UGID: "12345"}},
+		},
+
+		// Default values
+		"Create a new user with default home": {
+			name:   "test-user",
+			home:   "",
+			uuid:   "some-uuid",
+			shell:  "/usr/bin/zsh",
+			gecos:  "Test User",
+			groups: []info.Group{{Name: "test-group", UGID: "12345"}},
+		},
+		"Create a new user with default shell": {
+			name:   "test-user",
+			home:   "/home/test-user",
+			uuid:   "some-uuid",
+			shell:  "",
+			gecos:  "Test User",
+			groups: []info.Group{{Name: "test-group", UGID: "12345"}},
+		},
+		"Create a new user with default gecos": {name: "test-user",
+			home:   "/home/test-user",
+			uuid:   "some-uuid",
+			shell:  "/usr/bin/zsh",
+			gecos:  "",
+			groups: []info.Group{{Name: "test-group", UGID: "12345"}}},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			wantHome := tc.home
+			if tc.home == "" {
+				wantHome = tc.name
+			}
+
+			wantShell := tc.shell
+			if tc.shell == "" {
+				wantShell = "/usr/bin/bash"
+			}
+
+			wantGecos := tc.gecos
+			if tc.gecos == "" {
+				wantGecos = tc.name
+			}
+
+			got := info.NewUser(tc.name, tc.home, tc.uuid, tc.shell, tc.gecos, tc.groups)
+			require.Equal(t, tc.name, got.Name, "Name does not match the expected value")
+			require.Equal(t, wantHome, got.Home, "Home does not match the expected value")
+			require.Equal(t, tc.uuid, got.UUID, "UUID does not match the expected value")
+			require.Equal(t, wantShell, got.Shell, "Shell does not match the expected value")
+			require.Equal(t, wantGecos, got.Gecos, "Gecos does not match the expected value")
+			require.Equal(t, tc.groups, got.Groups, "Groups do not match the expected value")
+		})
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -2,7 +2,10 @@
 package providers
 
 import (
-	"github.com/ubuntu/authd-oidc-brokers/internal/providers/group"
+	"context"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/ubuntu/authd-oidc-brokers/internal/providers/info"
 	"golang.org/x/oauth2"
 )
 
@@ -18,5 +21,5 @@ type ProviderInfoer interface {
 		endpoints map[string]struct{},
 		currentAuthStep int,
 	) ([]string, error)
-	GetGroups(*oauth2.Token) ([]group.Info, error)
+	GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error)
 }


### PR DESCRIPTION
We used to control how the ID token was parsed into claims in the broker. This would become progressively unmaintainable as each provider could understand the claims differently. 

Instead of enforcing the providers to use the email as the username for local authentication, they control what will be parsed from the ID Token and return a UserInfo to the broker, which only fills the empty values with defaults (if any).

ubuntu/authd#439

UDENG-3698