### PR TITLE
tests: Add tests for concurrent IsAuthenticated calls

### DIFF
--- a/internal/broker/helper_test.go
+++ b/internal/broker/helper_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -138,6 +139,11 @@ func generateCachedInfo(t *testing.T, preexistentToken, issuer string) *broker.A
 		username = "test-user@email.com"
 	}
 
+	// This is to handle delay cases where we need to control the authentication ordering.
+	if strings.HasPrefix(preexistentToken, "user-timeout-") {
+		username = preexistentToken
+	}
+
 	idToken := fmt.Sprintf(`{
 		"iss": "%s",
 		"sub": "saved-user-id",
@@ -163,6 +169,11 @@ func generateCachedInfo(t *testing.T, preexistentToken, issuer string) *broker.A
 			{Name: "saved-remote-group", UGID: "12345"},
 			{Name: "saved-local-group", UGID: ""},
 		},
+	}
+
+	// This is to force the broker to query the provider for the user info.
+	if strings.HasPrefix(preexistentToken, "user-timeout-") {
+		tok.UserInfo = info.User{}
 	}
 
 	if preexistentToken == "invalid-id" {

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/cache/provider_url/user-timeout-0.cache
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/cache/provider_url/user-timeout-0.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/cache/provider_url/user-timeout-1.cache
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/cache/provider_url/user-timeout-1.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/first_auth
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/first_auth
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"user-timeout-0","uuid":"saved-user-id","dir":"/home/user-timeout-0","shell":"/usr/bin/bash","gecos":"user-timeout-0","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+err: <nil>

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/second_auth
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_and_finishes_before_second/second_auth
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"user-timeout-1","uuid":"saved-user-id","dir":"/home/user-timeout-1","shell":"/usr/bin/bash","gecos":"user-timeout-1","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+err: <nil>

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/cache/provider_url/user-timeout-1.cache
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/cache/provider_url/user-timeout-1.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/cache/provider_url/user-timeout-3.cache
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/cache/provider_url/user-timeout-3.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/first_auth
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/first_auth
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"user-timeout-3","uuid":"saved-user-id","dir":"/home/user-timeout-3","shell":"/usr/bin/bash","gecos":"user-timeout-3","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+err: <nil>

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/second_auth
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_but_second_finishes_first/second_auth
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"user-timeout-1","uuid":"saved-user-id","dir":"/home/user-timeout-1","shell":"/usr/bin/bash","gecos":"user-timeout-1","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+err: <nil>

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/cache/provider_url/user-timeout-2.cache
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/cache/provider_url/user-timeout-2.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/cache/provider_url/user-timeout-3.cache
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/cache/provider_url/user-timeout-3.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/first_auth
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/first_auth
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"user-timeout-2","uuid":"saved-user-id","dir":"/home/user-timeout-2","shell":"/usr/bin/bash","gecos":"user-timeout-2","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+err: <nil>

--- a/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/second_auth
+++ b/internal/broker/testdata/TestConcurrentIsAuthenticated/golden/first_auth_starts_first_then_second_starts_and_first_finishes/second_auth
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"user-timeout-3","uuid":"saved-user-id","dir":"/home/user-timeout-3","shell":"/usr/bin/bash","gecos":"user-timeout-3","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+err: <nil>


### PR DESCRIPTION
This is to ensure one session does not interfere with another when happening at the same time on the broker. To understand better the tests, run them with the verbosity flag (-v) so that you can see the ordering of the calls.

UDENG-2974