### PR TITLE
Fix nil pointer dereference in getGroups

### DIFF
--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -108,6 +108,10 @@ func (p Provider) getGroups(token *oauth2.Token) ([]info.Group, error) {
 	if err != nil {
 		return nil, err
 	}
+	if m == nil {
+		slog.Debug("Got nil response from Microsoft Graph API for user's groups, assuming that user is not a member of any group.")
+		return []info.Group{}, nil
+	}
 
 	var groups []info.Group
 	for _, obj := range m.GetValue() {


### PR DESCRIPTION
Handle the case that `TransitiveMemberOf().Get()` returns `nil, nil`.

UDENG-3908