### PR TITLE
Re-use the existing local password

### DIFF
--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -198,8 +198,7 @@ func (p Provider) CurrentAuthenticationModesOffered(
 		}
 		if tokenExists {
 			offeredModes = append([]string{"password"}, offeredModes...)
-		}
-		if currentAuthStep > 0 {
+		} else if currentAuthStep > 0 {
 			offeredModes = []string{"newpassword"}
 		}
 	}


### PR DESCRIPTION
When authenticating again via remote auth, do not ask user to set a new password if there already is a local password set. Ask for the existing password instead.

Closes https://github.com/ubuntu/authd/issues/369

UDENG-3116