### PR TITLE
Improve error messages returned by the broker

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -527,14 +527,7 @@ func TestIsAuthenticated(t *testing.T) {
 				access, data, err := b.IsAuthenticated(sessionID, authData)
 				require.True(t, json.Valid([]byte(data)), "IsAuthenticated returned data must be a valid JSON")
 
-				// Redact variant values from the response
-				data = strings.ReplaceAll(data, sessionID, "SESSION_ID")
-				data = strings.ReplaceAll(data, filepath.Dir(b.TokenPathForSession(sessionID)), "provider_cache_path")
-				data = strings.ReplaceAll(data, provider.URL, "provider_url")
-				errStr := strings.ReplaceAll(fmt.Sprintf("%v", err), sessionID, "SESSION_ID")
-
-				got := isAuthenticatedResponse{Access: access, Data: data, Err: errStr}
-
+				got := isAuthenticatedResponse{Access: access, Data: data, Err: fmt.Sprint(err)}
 				out, err := yaml.Marshal(got)
 				require.NoError(t, err, "Failed to marshal first response")
 
@@ -569,13 +562,7 @@ func TestIsAuthenticated(t *testing.T) {
 					access, data, err := b.IsAuthenticated(sessionID, secondAuthData)
 					require.True(t, json.Valid([]byte(data)), "IsAuthenticated returned data must be a valid JSON")
 
-					// Redact variant values from the response
-					data = strings.ReplaceAll(data, sessionID, "SESSION_ID")
-					data = strings.ReplaceAll(data, filepath.Dir(b.TokenPathForSession(sessionID)), "provider_cache_path")
-					data = strings.ReplaceAll(data, provider.URL, "provider_url")
-					errStr := strings.ReplaceAll(fmt.Sprintf("%v", err), sessionID, "SESSION_ID")
-
-					got := isAuthenticatedResponse{Access: access, Data: data, Err: errStr}
+					got := isAuthenticatedResponse{Access: access, Data: data, Err: fmt.Sprint(err)}
 					out, err := yaml.Marshal(got)
 					require.NoError(t, err, "Failed to marshal second response")
 
@@ -654,7 +641,6 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 			require.NoError(t, err, "Setup: SaveToken should not have returned an error")
 
 			firstCallDone := make(chan struct{})
-			//nolint:dupl // This is not a duplicate, just a very similar set of calls.
 			go func() {
 				t.Logf("%s: First auth starting", t.Name())
 				defer close(firstCallDone)
@@ -666,14 +652,7 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 				access, data, err := b.IsAuthenticated(firstSession, authData)
 				require.True(t, json.Valid([]byte(data)), "IsAuthenticated returned data must be a valid JSON")
 
-				// Redact variant values from the response
-				data = strings.ReplaceAll(data, firstSession, "SESSION_ID")
-				data = strings.ReplaceAll(data, filepath.Dir(b.TokenPathForSession(firstSession)), "provider_cache_path")
-				data = strings.ReplaceAll(data, defaultProvider.URL, "provider_url")
-				errStr := strings.ReplaceAll(fmt.Sprintf("%v", err), firstSession, "SESSION_ID")
-
-				got := isAuthenticatedResponse{Access: access, Data: data, Err: errStr}
-
+				got := isAuthenticatedResponse{Access: access, Data: data, Err: fmt.Sprint(err)}
 				out, err := yaml.Marshal(got)
 				require.NoError(t, err, "Failed to marshal first response")
 
@@ -686,7 +665,6 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 			time.Sleep(tc.timeBetween)
 
 			secondCallDone := make(chan struct{})
-			//nolint:dupl // This is not a duplicate, just a very similar set of calls.
 			go func() {
 				t.Logf("%s: Second auth starting", t.Name())
 				defer close(secondCallDone)
@@ -698,14 +676,7 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 				access, data, err := b.IsAuthenticated(secondSession, authData)
 				require.True(t, json.Valid([]byte(data)), "IsAuthenticated returned data must be a valid JSON")
 
-				// Redact variant values from the response
-				data = strings.ReplaceAll(data, secondSession, "SESSION_ID")
-				data = strings.ReplaceAll(data, filepath.Dir(b.TokenPathForSession(secondSession)), "provider_cache_path")
-				data = strings.ReplaceAll(data, defaultProvider.URL, "provider_url")
-				errStr := strings.ReplaceAll(fmt.Sprintf("%v", err), secondSession, "SESSION_ID")
-
-				got := isAuthenticatedResponse{Access: access, Data: data, Err: errStr}
-
+				got := isAuthenticatedResponse{Access: access, Data: data, Err: fmt.Sprint(err)}
 				out, err := yaml.Marshal(got)
 				require.NoError(t, err, "Failed to marshal second response")
 

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_can_not_cache_token/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_can_not_cache_token/second_call
@@ -1,3 +1,3 @@
-access: retry
-data: '{"message":"could not update cached info: could not cache info: could not create token directory: mkdir provider_cache_path: permission denied"}'
+access: denied
+data: '{"message":"authentication failure: could not cache user info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_can_not_be_decrypted/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_challenge_can_not_be_decrypted/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not decode challenge: could not decode challenge"}'
+data: '{"message":"authentication failure: could not decode challenge"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_empty_challenge_is_provided_for_local_password/second_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"challenge must not be empty"}'
+data: '{"message":"authentication failure: empty challenge"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_isauthenticated_is_ongoing_for_session/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_isauthenticated_is_ongoing_for_session/second_call
@@ -1,3 +1,3 @@
 access: denied
 data: '{}'
-err: IsAuthenticated already running for session "SESSION_ID"
+err: authentication already running for this user session

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_can_not_fetch_user_info/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_can_not_fetch_user_info/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"could not get required information"}'
+data: '{"message":"authentication failure: could not get required information"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_id_token_is_not_set/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_id_token_is_not_set/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"could not get required information"}'
+data: '{"message":"authentication failure: could not get required information"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_token_is_not_set/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_newpassword_and_token_is_not_set/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"could not get required information"}'
+data: '{"message":"authentication failure: could not get required information"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_cached_token_can't_be_refreshed/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_cached_token_can't_be_refreshed/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: could not load cached info: could not refresh token: oauth2: token expired and refresh token is not set"}'
+data: '{"message":"authentication failure: could not load cached info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_can_not_fetch_user_info/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_can_not_fetch_user_info/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"could not get user info: could not fetch user info: could not verify token: oidc: failed to unmarshal claims: invalid character ''\\u008a'' looking for beginning of value"}'
+data: '{"message":"authentication failure: could not fetch user info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_does_not_exist/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_does_not_exist/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: could not load cached info: could not read token: open provider_cache_path/test-user@email.com.cache: no such file or directory"}'
+data: '{"message":"authentication failure: could not load cached info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_is_invalid/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_is_invalid/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: could not load cached info: could not unmarshal token: invalid character ''T'' looking for beginning of value"}'
+data: '{"message":"authentication failure: could not load cached info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_refresh_times_out/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_and_token_refresh_times_out/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: could not load cached info: could not refresh token: Post \"provider_url/token\": context deadline exceeded"}'
+data: '{"message":"authentication failure: could not load cached info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_but_server_returns_error/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_password_but_server_returns_error/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: could not load cached info: could not refresh token: oauth2: cannot fetch token: 400 Bad Request\nResponse: "}'
+data: '{"message":"authentication failure: could not load cached info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: oauth2: cannot fetch token: 503 Service Unavailable\nResponse: "}'
+data: '{"message":"authentication failure: could not authenticate user remotely"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token_due_to_timeout/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_can_not_get_token_due_to_timeout/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: oauth2: cannot fetch token: 408 Request Timeout\nResponse: "}'
+data: '{"message":"authentication failure: could not authenticate user remotely"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_link_expires/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_link_expires/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: context deadline exceeded"}'
+data: '{"message":"authentication failure: could not authenticate user remotely"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_response_is_invalid/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_mode_is_qrcode_and_response_is_invalid/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"could not get required response"}'
+data: '{"message":"authentication failure: could not get required response"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_provided_wrong_challenge/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_provided_wrong_challenge/first_call
@@ -1,3 +1,3 @@
 access: retry
-data: '{"message":"could not authenticate user: could not load cached info: could not deserialize token: cipher: message authentication failed"}'
+data: '{"message":"authentication failure: could not load cached info"}'
 err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/error_when_selected_username_does_not_match_the_provider_one/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/error_when_selected_username_does_not_match_the_provider_one/first_call
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"could not get user info: could not fetch user info: returned user \"test-user@email.com\" does not match the selected one \"not-matching\""}'
+data: '{"message":"authentication failure: could not fetch user info"}'
 err: <nil>


### PR DESCRIPTION
Exposing too much on the error messages can allow attackers to grab sensitive information by forcing authentication failures. To prevent leaks, we now print the full error message on the system logs and return a simpler one through dbus.

The difference between what we had and the new ones can be seen in the golden files updated in this PR. The full error message is printed to the logs and can be looked at by running `go test -v`.

UDENG-4076