### PR TITLE
Use more descriptive error messages

### DIFF
--- a/internal/providers/noprovider/noprovider.go
+++ b/internal/providers/noprovider/noprovider.go
@@ -99,7 +99,7 @@ type claims struct {
 func (p NoProvider) userClaims(idToken *oidc.IDToken) (claims, error) {
 	var userClaims claims
 	if err := idToken.Claims(&userClaims); err != nil {
-		return claims{}, fmt.Errorf("could not get user info: %v", err)
+		return claims{}, fmt.Errorf("failed to get ID token claims: %v", err)
 	}
 	return userClaims, nil
 }

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -285,7 +285,7 @@ type claims struct {
 func (p *MockProviderInfoer) userClaims(idToken *oidc.IDToken) (claims, error) {
 	var userClaims claims
 	if err := idToken.Claims(&userClaims); err != nil {
-		return claims{}, fmt.Errorf("could not get user info: %v", err)
+		return claims{}, fmt.Errorf("failed to get ID token claims: %v", err)
 	}
 	return userClaims, nil
 }


### PR DESCRIPTION
We used "could not get user info" in too many places, making it hard to tell where this error message originated from.