### PR TITLE
Improve errors when failing to parse config and create broker

### DIFF
--- a/internal/dbusservice/internal_test.go
+++ b/internal/dbusservice/internal_test.go
@@ -1,0 +1,99 @@
+package dbusservice
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd-oidc-brokers/internal/testutils"
+)
+
+var configTypes = map[string]string{
+	"valid": `
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+`,
+
+	"valid+optional": `
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+
+[users]
+home_base_dir = /home
+allowed_ssh_suffixes = @issuer.url.com
+`,
+
+	"singles": `
+[oidc]
+issuer = https://ISSUER_URL>
+client_id = <CLIENT_ID
+`,
+
+	"template": `
+[oidc]
+issuer = https://<ISSUER_URL>
+client_id = <CLIENT_ID>
+`,
+}
+
+func TestParseConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		configType string
+
+		wantErr bool
+	}{
+		"Successfully parse config file":                      {},
+		"Successfully parse config file with optional values": {configType: "valid+optional"},
+
+		"Do not fail if values contain a single template delimiter": {configType: "singles"},
+
+		"Error if file does not exist": {configType: "inexistent", wantErr: true},
+		"Error if file is unreadable":  {configType: "unreadable", wantErr: true},
+		"Error if file is not updated": {configType: "template", wantErr: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			confPath := filepath.Join(t.TempDir(), "broker.conf")
+
+			if tc.configType == "" {
+				tc.configType = "valid"
+			}
+			err := os.WriteFile(confPath, []byte(configTypes[tc.configType]), 0600)
+			require.NoError(t, err, "Setup: Failed to write config file")
+
+			switch tc.configType {
+			case "inexistent":
+				err = os.Remove(confPath)
+				require.NoError(t, err, "Setup: Failed to remove config file")
+			case "unreadable":
+				err = os.Chmod(confPath, 0000)
+				require.NoError(t, err, "Setup: Failed to make config file unreadable")
+			}
+
+			got, err := parseConfig(confPath)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
+			require.EqualValues(t, want, got)
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	testutils.InstallUpdateFlag()
+	flag.Parse()
+
+	m.Run()
+}

--- a/internal/dbusservice/testdata/TestParseConfig/golden/do_not_fail_if_values_contain_a_single_template_delimiter
+++ b/internal/dbusservice/testdata/TestParseConfig/golden/do_not_fail_if_values_contain_a_single_template_delimiter
@@ -1,0 +1,4 @@
+DEFAULT: {}
+oidc:
+    client_id: <CLIENT_ID
+    issuer: https://ISSUER_URL>

--- a/internal/dbusservice/testdata/TestParseConfig/golden/successfully_parse_config_file
+++ b/internal/dbusservice/testdata/TestParseConfig/golden/successfully_parse_config_file
@@ -1,0 +1,4 @@
+DEFAULT: {}
+oidc:
+    client_id: client_id
+    issuer: https://issuer.url.com

--- a/internal/dbusservice/testdata/TestParseConfig/golden/successfully_parse_config_file_with_optional_values
+++ b/internal/dbusservice/testdata/TestParseConfig/golden/successfully_parse_config_file_with_optional_values
@@ -1,0 +1,7 @@
+DEFAULT: {}
+oidc:
+    client_id: client_id
+    issuer: https://issuer.url.com
+users:
+    allowed_ssh_suffixes: '@issuer.url.com'
+    home_base_dir: /home


### PR DESCRIPTION
The details are better explained in the commit messages, but TLDR: we now have more directed errors to specific failures and are now evaluating whether the configuration file was edited or it's the same as the template one.

UDENG-3929