### PR TITLE
Print warning if an expected scope is missing

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -360,6 +360,7 @@ func TestIsAuthenticated(t *testing.T) {
 		badFirstKey    bool
 
 		customHandlers map[string]testutils.ProviderHandler
+		address        string
 
 		wantSecondCall  bool
 		secondChallenge string
@@ -387,6 +388,14 @@ func TestIsAuthenticated(t *testing.T) {
 			customHandlers: map[string]testutils.ProviderHandler{
 				"/.well-known/openid-configuration": testutils.UnavailableHandler(),
 			},
+		},
+		"Authenticating still allowed if token is missing scopes": {
+			firstChallenge: "-",
+			wantSecondCall: true,
+			customHandlers: map[string]testutils.ProviderHandler{
+				"/token": testutils.DefaultTokenHandler("http://127.0.0.1:31313", []string{}),
+			},
+			address: "127.0.0.1:31313",
 		},
 
 		"Error when authentication data is invalid":         {invalidAuthData: true},
@@ -466,7 +475,7 @@ func TestIsAuthenticated(t *testing.T) {
 				for path, handler := range tc.customHandlers {
 					opts = append(opts, testutils.WithHandler(path, handler))
 				}
-				p, cleanup := testutils.StartMockProvider("", opts...)
+				p, cleanup := testutils.StartMockProvider(tc.address, opts...)
 				t.Cleanup(cleanup)
 				provider = p
 			}

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_still_allowed_if_token_is_missing_scopes/cache/provider_url/test-user@email.com.cache
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_still_allowed_if_token_is_missing_scopes/cache/provider_url/test-user@email.com.cache
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_still_allowed_if_token_is_missing_scopes/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_still_allowed_if_token_is_missing_scopes/first_call
@@ -1,0 +1,3 @@
+access: next
+data: '{}'
+err: <nil>

--- a/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_still_allowed_if_token_is_missing_scopes/second_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/authenticating_still_allowed_if_token_is_missing_scopes/second_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+err: <nil>

--- a/internal/consts/oidc.go
+++ b/internal/consts/oidc.go
@@ -1,0 +1,9 @@
+package consts
+
+import "github.com/coreos/go-oidc/v3/oidc"
+
+var (
+	// DefaultScopes contains the OIDC scopes that we require for all providers.
+	// Provider implementations can append additional scopes.
+	DefaultScopes = []string{oidc.ScopeOpenID, "profile", "email"}
+)

--- a/internal/providers/default.go
+++ b/internal/providers/default.go
@@ -8,5 +8,5 @@ import (
 
 // CurrentProviderInfo returns a generic oidc provider implementation.
 func CurrentProviderInfo() ProviderInfoer {
-	return noprovider.NoProvider{}
+	return noprovider.New()
 }

--- a/internal/providers/msentraid/export_test.go
+++ b/internal/providers/msentraid/export_test.go
@@ -1,0 +1,8 @@
+package msentraid
+
+import "strings"
+
+// AllExpectedScopes returns all the default expected scopes for a new provider.
+func AllExpectedScopes() string {
+	return strings.Join(New().expectedScopes, " ")
+}

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -58,13 +58,16 @@ func (p Provider) CheckTokenScopes(token *oauth2.Token) error {
 	}
 
 	scopes := strings.Split(scopesStr, " ")
-	var errs []error
+	var missingScopes []string
 	for _, s := range p.expectedScopes {
 		if !slices.Contains(scopes, s) {
-			errs = append(errs, fmt.Errorf("token is missing scope %q", s))
+			missingScopes = append(missingScopes, s)
 		}
 	}
-	return errors.Join(errs...)
+	if len(missingScopes) > 0 {
+		return fmt.Errorf("missing required scopes: %s", strings.Join(missingScopes, ", "))
+	}
+	return nil
 }
 
 // GetUserInfo is a no-op when no specific provider is in use.

--- a/internal/providers/msentraid/msentraid_test.go
+++ b/internal/providers/msentraid/msentraid_test.go
@@ -1,0 +1,53 @@
+package msentraid_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd-oidc-brokers/internal/providers/msentraid"
+	"golang.org/x/oauth2"
+)
+
+func TestNew(t *testing.T) {
+	p := msentraid.New()
+
+	require.NotEmpty(t, p, "New should return a non-empty provider")
+}
+
+func TestCheckTokenScopes(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		scopes            string
+		noExtraScopeField bool
+
+		wantErr bool
+	}{
+		"success when checking all scopes are present":       {scopes: msentraid.AllExpectedScopes()},
+		"success even if getting more scopes than requested": {scopes: msentraid.AllExpectedScopes() + " extra-scope"},
+
+		"error with missing scopes":       {scopes: "profile email", wantErr: true},
+		"error without extra scope field": {noExtraScopeField: true, wantErr: true},
+		"error with empty scopes":         {scopes: "", wantErr: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := msentraid.New()
+
+			token := &oauth2.Token{}
+			if !tc.noExtraScopeField {
+				token = token.WithExtra(map[string]interface{}{"scope": any(tc.scopes)})
+			}
+
+			err := p.CheckTokenScopes(token)
+			if tc.wantErr {
+				require.Error(t, err, "CheckTokenScopes should return an error")
+				return
+			}
+
+			require.NoError(t, err, "CheckTokenScopes should not return an error")
+		})
+	}
+}

--- a/internal/providers/noprovider/noprovider.go
+++ b/internal/providers/noprovider/noprovider.go
@@ -14,6 +14,17 @@ import (
 // NoProvider is a generic OIDC provider.
 type NoProvider struct{}
 
+// New returns a new NoProvider.
+func New() NoProvider {
+	return NoProvider{}
+}
+
+// CheckTokenScopes should check the token scopes, but we're not sure
+// if there is a generic way to do this, so for now it's a no-op.
+func (p NoProvider) CheckTokenScopes(token *oauth2.Token) error {
+	return nil
+}
+
 // AdditionalScopes returns the generic scopes required by the provider.
 func (p NoProvider) AdditionalScopes() []string {
 	return []string{oidc.ScopeOfflineAccess}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -13,6 +13,7 @@ import (
 type ProviderInfoer interface {
 	AdditionalScopes() []string
 	AuthOptions() []oauth2.AuthCodeOption
+	CheckTokenScopes(token *oauth2.Token) error
 	CurrentAuthenticationModesOffered(
 		sessionMode string,
 		supportedAuthModes map[string]string,

--- a/internal/providers/withmsentraid.go
+++ b/internal/providers/withmsentraid.go
@@ -8,5 +8,5 @@ import (
 
 // CurrentProviderInfo returns a Microsoft Entra ID provider implementation.
 func CurrentProviderInfo() ProviderInfoer {
-	return msentraid.Provider{}
+	return msentraid.New()
 }


### PR DESCRIPTION
Should make it easier to debug scope-related issues even if the user didn't enable verbose logs.

UDENG-4347