### PR TITLE
ci: Block merging PRs with fixup commits

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,12 @@
+name: Git Checks
+
+on: [pull_request]
+
+jobs:
+  block-fixup:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2.0.0
+    - name: Block Fixup Commit Merge
+      uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
We want to avoid force pushing to PRs which have already been reviewed, so we're doing fixup commits instead. To keep a clean git history, those should be squashed before merging (with `git rebase --autosquash`).

This new GitHub action should avoid that we accidentally merge PRs which have unsquashed fixup commits.