### PR TITLE
Move user name comparison to provider

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -711,9 +711,8 @@ func (b *Broker) fetchUserInfo(ctx context.Context, session *sessionInfo, t *aut
 		return info.User{}, fmt.Errorf("could not get user info: %w", err)
 	}
 
-	// Some providers are case-insensitive, but we are not. So we need to lowercase the returned username.
-	if !strings.EqualFold(userInfo.Name, session.username) {
-		return info.User{}, fmt.Errorf("returned user %q does not match the selected one %q", userInfo.Name, session.username)
+	if err = b.providerInfo.VerifyUsername(session.username, userInfo.Name); err != nil {
+		return info.User{}, fmt.Errorf("username verification failed: %w", err)
 	}
 
 	// This means that home was not provided by the claims, so we need to set it to the broker default.

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -736,7 +736,6 @@ func TestFetchUserInfo(t *testing.T) {
 		"Successfully fetch user info with groups":                         {},
 		"Successfully fetch user info without groups":                      {emptyGroups: true},
 		"Successfully fetch user info with default home when not provided": {emptyHomeDir: true},
-		"Successfully fetch user info ignoring different casing in name":   {userToken: "uppercased-name"},
 
 		"Error when token can not be validated":                   {userToken: "invalid", wantErr: true},
 		"Error when ID token claims are invalid":                  {userToken: "invalid-id", wantErr: true},

--- a/internal/broker/helper_test.go
+++ b/internal/broker/helper_test.go
@@ -133,8 +133,6 @@ func generateCachedInfo(t *testing.T, preexistentToken, issuer string) *broker.A
 		username = ""
 	case "other-name":
 		username = "other-user@email.com"
-	case "uppercased-name":
-		username = "TEST-USER@EMAIL.COM"
 	default:
 		username = "test-user@email.com"
 	}

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -247,6 +247,15 @@ func (p Provider) CurrentAuthenticationModesOffered(
 	return offeredModes, nil
 }
 
+// VerifyUsername checks if the authenticated username matches the requested username.
+func (p Provider) VerifyUsername(requestedUsername, authenticatedUsername string) error {
+	// Microsoft Entra usernames are case-insensitive.
+	if !strings.EqualFold(requestedUsername, authenticatedUsername) {
+		return fmt.Errorf("requested username %q does not match the authenticated user %q", requestedUsername, authenticatedUsername)
+	}
+	return nil
+}
+
 type azureTokenCredential struct {
 	token *oauth2.Token
 }

--- a/internal/providers/msentraid/msentraid_test.go
+++ b/internal/providers/msentraid/msentraid_test.go
@@ -51,3 +51,34 @@ func TestCheckTokenScopes(t *testing.T) {
 		})
 	}
 }
+
+func TestVerifyUsername(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		requestedUsername string
+		authenticatedUser string
+
+		wantErr bool
+	}{
+		"Success when usernames are the same":   {requestedUsername: "foo@bar", authenticatedUser: "foo@bar"},
+		"Success when usernames differ in case": {requestedUsername: "foo@bar", authenticatedUser: "Foo@bar"},
+
+		"Error when usernames differ": {requestedUsername: "foo@bar", authenticatedUser: "bar@foo", wantErr: true},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			p := msentraid.New()
+
+			err := p.VerifyUsername(tc.requestedUsername, tc.authenticatedUser)
+			if tc.wantErr {
+				require.Error(t, err, "VerifyUsername should return an error")
+				return
+			}
+
+			require.NoError(t, err, "VerifyUsername should not return an error")
+		})
+	}
+}

--- a/internal/providers/msentraid/msentraid_test.go
+++ b/internal/providers/msentraid/msentraid_test.go
@@ -65,6 +65,12 @@ func TestVerifyUsername(t *testing.T) {
 		"Success when usernames differ in case": {requestedUsername: "foo@bar", authenticatedUser: "Foo@bar"},
 
 		"Error when usernames differ": {requestedUsername: "foo@bar", authenticatedUser: "bar@foo", wantErr: true},
+		"Error when requested username contains invalid characters": {
+			requestedUsername: "fóó@bar", authenticatedUser: "foo@bar", wantErr: true,
+		},
+		"Error when authenticated username contains invalid characters": {
+			requestedUsername: "foo@bar", authenticatedUser: "fóó@bar", wantErr: true,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/providers/msentraid/msentraid_test.go
+++ b/internal/providers/msentraid/msentraid_test.go
@@ -23,12 +23,12 @@ func TestCheckTokenScopes(t *testing.T) {
 
 		wantErr bool
 	}{
-		"success when checking all scopes are present":       {scopes: msentraid.AllExpectedScopes()},
-		"success even if getting more scopes than requested": {scopes: msentraid.AllExpectedScopes() + " extra-scope"},
+		"Success when checking all scopes are present":       {scopes: msentraid.AllExpectedScopes()},
+		"Success even if getting more scopes than requested": {scopes: msentraid.AllExpectedScopes() + " extra-scope"},
 
-		"error with missing scopes":       {scopes: "profile email", wantErr: true},
-		"error without extra scope field": {noExtraScopeField: true, wantErr: true},
-		"error with empty scopes":         {scopes: "", wantErr: true},
+		"Error with missing scopes":       {scopes: "profile email", wantErr: true},
+		"Error without extra scope field": {noExtraScopeField: true, wantErr: true},
+		"Error with empty scopes":         {scopes: "", wantErr: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/providers/noprovider/noprovider.go
+++ b/internal/providers/noprovider/noprovider.go
@@ -98,6 +98,14 @@ func (p NoProvider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, 
 	), nil
 }
 
+// VerifyUsername checks if the requested username matches the authenticated user.
+func (p NoProvider) VerifyUsername(requestedUsername, username string) error {
+	if requestedUsername != username {
+		return fmt.Errorf("requested username %q does not match the authenticated user %q", requestedUsername, username)
+	}
+	return nil
+}
+
 type claims struct {
 	PreferredUserName string `json:"preferred_username"`
 	Sub               string `json:"sub"`

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -23,4 +23,5 @@ type ProviderInfoer interface {
 		currentAuthStep int,
 	) ([]string, error)
 	GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error)
+	VerifyUsername(requestedUsername, authenticatedUsername string) error
 }

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -363,3 +363,11 @@ func (p MockProviderInfoer) CurrentAuthenticationModesOffered(
 
 	return offeredModes, nil
 }
+
+// VerifyUsername checks if the requested username matches the authenticated user.
+func (p *MockProviderInfoer) VerifyUsername(requestedUsername, username string) error {
+	if requestedUsername != username {
+		return fmt.Errorf("requested username %q does not match the authenticated user %q", requestedUsername, username)
+	}
+	return nil
+}


### PR DESCRIPTION
The decision whether two usernames are considered equal is provider-specific. For example, some providers have case-insensitive usernames.

UDENG-4414
UDENG-4517