### PR TITLE
Avoid false positive nolintlint error

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ linters:
     - durationcheck
     - errname
     - errorlint
-    - exportloopref
+    - copyloopvar
     - forbidigo
     - forcetypeassert
     - gci

--- a/cmd/authd-oidc/daemon/export_test.go
+++ b/cmd/authd-oidc/daemon/export_test.go
@@ -76,7 +76,7 @@ client_id = client_id
 
 // Config returns a DaemonConfig for tests.
 //
-//nolint:revive // DaemonConfig is a type alias for tests
+//nolint:revive,nolintlint // DaemonConfig is a type alias for tests
 func (a App) Config() DaemonConfig {
 	return a.config
 }


### PR DESCRIPTION
When running golangci-lint locally, the "nolintlint" linter complained
that the nolint:revive directive is unused:

	directive `//nolint:revive // DaemonConfig is a type alias for tests` is unused for linter "revive" (nolintlint)

When removing that directive, the "revive" linter complains in the
GitHub Action:

	unexported-return: exported method Config returns unexported type daemon.daemonConfig, which can be annoying to use (revive)

This commit disables both "revive" and "nolintlint" to make
golangci-lint pass both in the CI and locally.
