### PR TITLE
Update user info even on local authentication

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -482,7 +482,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *sessionInfo
 			return AuthRetry, errorMessage{Message: "could not load cached info"}
 		}
 
-		if authInfo.UserInfo.Name == "" {
+		if !session.isOffline {
 			authInfo.UserInfo, err = b.fetchUserInfo(ctx, session, &authInfo)
 			if err != nil {
 				slog.Error(err.Error())

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -379,7 +379,7 @@ func TestIsAuthenticated(t *testing.T) {
 			firstMode:        "password",
 			preexistentToken: "valid",
 			customHandlers: map[string]testutils.ProviderHandler{
-				"/token": testutils.UnavailableHandler(),
+				"/.well-known/openid-configuration": testutils.UnavailableHandler(),
 			},
 		},
 		"Authenticating with password still allowed if token is expired and server is unreachable": {

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>


### PR DESCRIPTION
We used to rely on the cached information if the access token was still valid. Now, we always try to fetch the user information (username, groups, etc) if the session is online, even if we did not refresh the token.

UDENG-4436