### PR TITLE
Revert "Update user info even on local authentication"

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -482,7 +482,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *sessionInfo
 			return AuthRetry, errorMessage{Message: "could not load cached info"}
 		}
 
-		if !session.isOffline {
+		if authInfo.UserInfo.Name == "" {
 			authInfo.UserInfo, err = b.fetchUserInfo(ctx, session, &authInfo)
 			if err != nil {
 				slog.Error(err.Error())

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
 err: <nil>


### PR DESCRIPTION
Commit 30d23aca2baedb29b3c0c60e87d8a300c0ff50b4 broke local authentication when the access token is _not_ expired. With that commit, we tried to get the groups with the locally stored token, which in case of the MSEntraID provider, returns an error when the scopes field doesn't contain the GroupMember.Read.All scope. The problem is that we don't store the extra scopes field of the token locally, so it always fails with:

    could not get user info: failed to cast token scopes to string: <nil>.

This reverts commit 30d23aca2baedb29b3c0c60e87d8a300c0ff50b4.

UDENG-4482