### PR TITLE
Revert "Check that usernames comply with the Microsoft Entra username policy"

### DIFF
--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -248,27 +247,12 @@ func (p Provider) CurrentAuthenticationModesOffered(
 	return offeredModes, nil
 }
 
-// VerifyUsername checks if the authenticated username matches the requested username and that both are valid.
+// VerifyUsername checks if the authenticated username matches the requested username.
 func (p Provider) VerifyUsername(requestedUsername, authenticatedUsername string) error {
-	// Microsoft Entra usernames are case-insensitive. We can safely use strings.EqualFold here without worrying about
-	// different Unicode characters that fold to the same lowercase letter, because the Microsoft Entra username policy
-	// (which we checked above) ensures that the username only contains ASCII characters.
+	// Microsoft Entra usernames are case-insensitive.
 	if !strings.EqualFold(requestedUsername, authenticatedUsername) {
 		return fmt.Errorf("requested username %q does not match the authenticated user %q", requestedUsername, authenticatedUsername)
 	}
-
-	// Check that the usernames only contain the characters allowed by the Microsoft Entra username policy
-	// https://learn.microsoft.com/en-us/entra/identity/authentication/concept-sspr-policy#username-policies
-	usernameRegexp := regexp.MustCompile(`^[a-zA-Z0-9'.-_!#^~]+$`)
-	if !usernameRegexp.MatchString(authenticatedUsername) {
-		// If this error occurs, we should investigate and probably relax the username policy, so we ask the user
-		// explicitly to report this error.
-		return providerErrors.NewForDisplayError("the authenticated username %q contains invalid characters. Please report this error on https://github.com/ubuntu/authd/issues", authenticatedUsername)
-	}
-	if !usernameRegexp.MatchString(requestedUsername) {
-		return fmt.Errorf("requested username %q contains invalid characters", requestedUsername)
-	}
-
 	return nil
 }
 

--- a/internal/providers/msentraid/msentraid_test.go
+++ b/internal/providers/msentraid/msentraid_test.go
@@ -65,12 +65,6 @@ func TestVerifyUsername(t *testing.T) {
 		"Success when usernames differ in case": {requestedUsername: "foo@bar", authenticatedUser: "Foo@bar"},
 
 		"Error when usernames differ": {requestedUsername: "foo@bar", authenticatedUser: "bar@foo", wantErr: true},
-		"Error when requested username contains invalid characters": {
-			requestedUsername: "fóó@bar", authenticatedUser: "foo@bar", wantErr: true,
-		},
-		"Error when authenticated username contains invalid characters": {
-			requestedUsername: "foo@bar", authenticatedUser: "fóó@bar", wantErr: true,
-		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Commit 4b7f8f35d89ba2a9720a691f133a323015c9c827 broke device authentication with Microsoft Entra because it doesn't allow "@" in the username, but all Microsoft Entra user principal names (and emails) include an "@".

This reverts commit 4b7f8f35d89ba2a9720a691f133a323015c9c827.

UDENG-4563