### PR TITLE
Explicitly request the required permissions

### DIFF
--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -42,7 +42,7 @@ func New() Provider {
 
 // AdditionalScopes returns the generic scopes required by the EntraID provider.
 func (p Provider) AdditionalScopes() []string {
-	return []string{oidc.ScopeOfflineAccess}
+	return []string{oidc.ScopeOfflineAccess, "GroupMember.Read.All", "User.Read"}
 }
 
 // AuthOptions returns the generic auth options required by the EntraID provider.


### PR DESCRIPTION
A user reports that they added the required permissions ("GroupMember.Read.All" and "User.Read") to the Entra app but login fails with:

    level=WARN msg="missing required scopes: GroupMember.Read.All, User.Read"
    level=ERROR msg="could not get user into: the Microsoft Entra ID app is missing the GroupMember.Read.All permission"

That means that the response to the token request did contain the default permissions ("openid", "profile" and "email") which we specified in the "scope" parameter in the request, but not the other permissions ("GroupMember.Read.All" and "User.Read") which we expect to be there because the user added them to the app.

The API reference [1] for the "scope" parameter of the response states:

    Because the UserInfo endpoint is hosted on Microsoft Graph, it's
    possible for scope to contain others previously granted to the
    application (for example, User.Read).

[1] https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc#successful-token-response

The "It's possible" wording doesn't sound like we can rely on those permissions being included in all cases. Lets see if requesting them explicitly fixes the issue.