### PR TITLE
Replace deprecated linter 'exportloopref' with 'copyloopvar'

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,11 +4,11 @@
 linters:
   # linters to run in addition to default ones
   enable:
+    - copyloopvar
     - dupl
     - durationcheck
     - errname
     - errorlint
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - gci


### PR DESCRIPTION
golangci-lint complained:

    WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.