### PR TITLE
Always try to refresh the user info on local password login

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -461,7 +461,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *sessionInfo
 			return AuthDenied, errorMessage{Message: "could not get ID token"}
 		}
 
-		authInfo = authCachedInfo{Token: t, RawIDToken: rawIDToken}
+		authInfo = b.newAuthCachedInfo(t, rawIDToken)
 		authInfo.UserInfo, err = b.fetchUserInfo(ctx, session, &authInfo)
 		if err != nil {
 			slog.Error(err.Error())
@@ -628,9 +628,18 @@ func (b *Broker) updateSession(sessionID string, session sessionInfo) error {
 
 // authCachedInfo represents the token that will be saved on disk for offline authentication.
 type authCachedInfo struct {
-	Token      *oauth2.Token
-	RawIDToken string
-	UserInfo   info.User
+	Token       *oauth2.Token
+	ExtraFields map[string]interface{}
+	RawIDToken  string
+	UserInfo    info.User
+}
+
+func (b *Broker) newAuthCachedInfo(t *oauth2.Token, idToken string) authCachedInfo {
+	return authCachedInfo{
+		Token:       t,
+		RawIDToken:  idToken,
+		ExtraFields: b.providerInfo.GetExtraFields(t),
+	}
 }
 
 // cacheAuthInfo serializes the access token and cache it.
@@ -674,6 +683,11 @@ func (b *Broker) loadAuthInfo(ctx context.Context, session *sessionInfo, passwor
 		return authCachedInfo{}, fmt.Errorf("could not unmarshal token: %v", err)
 	}
 
+	// Set the extra fields of the token.
+	if cachedInfo.ExtraFields != nil {
+		cachedInfo.Token = cachedInfo.Token.WithExtra(cachedInfo.ExtraFields)
+	}
+
 	// If the token is still valid, we return it. Ideally, we would refresh it online, but the TokenSource API also uses
 	// this logic to decide whether the token needs refreshing, so we should run it early to control the returned values.
 	if cachedInfo.Token.Valid() || session.isOffline {
@@ -694,7 +708,7 @@ func (b *Broker) loadAuthInfo(ctx context.Context, session *sessionInfo, passwor
 		refreshedIDToken = cachedInfo.RawIDToken
 	}
 
-	return authCachedInfo{Token: tok, RawIDToken: refreshedIDToken}, nil
+	return b.newAuthCachedInfo(tok, refreshedIDToken), nil
 }
 
 func (b *Broker) fetchUserInfo(ctx context.Context, session *sessionInfo, t *authCachedInfo) (userInfo info.User, err error) {

--- a/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
+++ b/internal/broker/testdata/TestIsAuthenticated/golden/successfully_authenticate_user_with_password/first_call
@@ -1,3 +1,3 @@
 access: granted
-data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"saved-remote-group","ugid":"12345"},{"name":"saved-local-group","ugid":""}]}}'
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"saved-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-group","ugid":"12345"},{"name":"linux-local-group","ugid":""}]}}'
 err: <nil>

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -119,6 +119,8 @@ func (p Provider) userClaims(idToken *oidc.IDToken) (claims, error) {
 
 // getGroups access the Microsoft Graph API to get the groups the user is a member of.
 func (p Provider) getGroups(token *oauth2.Token) ([]info.Group, error) {
+	slog.Debug("Getting user groups from Microsoft Graph API")
+
 	// Check if the token has the GroupMember.Read.All scope
 	scopes, err := p.getTokenScopes(token)
 	if err != nil {
@@ -200,6 +202,7 @@ func getAllUserGroups(client *msgraphsdk.GraphServiceClient) ([]msgraphmodels.Gr
 		groups = append(groups, result.GetValue()...)
 	}
 
+	slog.Debug(fmt.Sprintf("Got groups: %v", groups))
 	return groups, nil
 }
 

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -78,6 +78,13 @@ func (p Provider) getTokenScopes(token *oauth2.Token) ([]string, error) {
 	return strings.Split(scopesStr, " "), nil
 }
 
+// GetExtraFields returns the extra fields of the token which should be stored persistently.
+func (p Provider) GetExtraFields(token *oauth2.Token) map[string]interface{} {
+	return map[string]interface{}{
+		"scope": token.Extra("scope"),
+	}
+}
+
 // GetUserInfo is a no-op when no specific provider is in use.
 func (p Provider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error) {
 	userClaims, err := p.userClaims(idToken)

--- a/internal/providers/noprovider/noprovider.go
+++ b/internal/providers/noprovider/noprovider.go
@@ -76,6 +76,11 @@ func (p NoProvider) CurrentAuthenticationModesOffered(
 	return offeredModes, nil
 }
 
+// GetExtraFields returns the extra fields of the token which should be stored persistently.
+func (p NoProvider) GetExtraFields(token *oauth2.Token) map[string]interface{} {
+	return nil
+}
+
 // GetUserInfo is a no-op when no specific provider is in use.
 func (p NoProvider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error) {
 	userClaims, err := p.userClaims(idToken)

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -22,6 +22,7 @@ type ProviderInfoer interface {
 		endpoints map[string]struct{},
 		currentAuthStep int,
 	) ([]string, error)
+	GetExtraFields(token *oauth2.Token) map[string]interface{}
 	GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error)
 	VerifyUsername(requestedUsername, authenticatedUsername string) error
 }

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -335,6 +335,11 @@ func (p *MockProviderInfoer) AuthOptions() []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{}
 }
 
+// GetExtraFields returns the extra fields of the token which should be stored persistently.
+func (p *MockProviderInfoer) GetExtraFields(token *oauth2.Token) map[string]interface{} {
+	return nil
+}
+
 // GetUserInfo is a no-op when no specific provider is in use.
 func (p *MockProviderInfoer) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error) {
 	userClaims, err := p.userClaims(idToken)


### PR DESCRIPTION
Before this commit, we only refreshed the user info during local
    password login when we retrieved a new access token (because the old one
    was expired). There's no reason to only do it then - as long as we have a
    valid access token, we can always try to refresh the user info.
    
With this commit, we always try to refresh the user info. If that fails
    for any reason, we log a warning and keep using the cached user info.


Closes #520
UDENG-4436