### PR TITLE
Optional client secret for some providers

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1,6 +1,9 @@
 [oidc]
 issuer = https://<ISSUER_URL>
 client_id = <CLIENT_ID>
+# Client secret is needed for some specific auth flows depending on the provider.
+# Only enable it if this is needed for your particular configuration.
+# client_secret = <CLIENT_SECRET>
 
 [users]
 # The directory where the home directory will be created for new users.

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -47,6 +47,7 @@ type Config struct {
 
 type userConfig struct {
 	clientID           string
+	clientSecret       string
 	issuerURL          string
 	homeBaseDir        string
 	allowedSSHSuffixes []string
@@ -213,9 +214,10 @@ func (b *Broker) connectToProvider(ctx context.Context) (authCfg authConfig, err
 	}
 
 	oauthCfg := oauth2.Config{
-		ClientID: b.oidcCfg.ClientID,
-		Endpoint: provider.Endpoint(),
-		Scopes:   append(consts.DefaultScopes, b.providerInfo.AdditionalScopes()...),
+		ClientID:     b.oidcCfg.ClientID,
+		ClientSecret: b.cfg.clientSecret,
+		Endpoint:     provider.Endpoint(),
+		Scopes:       append(consts.DefaultScopes, b.providerInfo.AdditionalScopes()...),
 	}
 
 	return authConfig{provider: provider, oauth: oauthCfg}, nil

--- a/internal/broker/config.go
+++ b/internal/broker/config.go
@@ -16,6 +16,8 @@ const (
 	issuerKey = "issuer"
 	// clientIDKey is the key in the config file for the client ID.
 	clientIDKey = "client_id"
+	// clientSecret is the optional client secret for this client.
+	clientSecret = "client_secret"
 
 	// usersSection is the section name in the config file for the users and broker specific configuration.
 	usersSection = "users"
@@ -50,6 +52,7 @@ func parseConfigFile(cfgPath string) (userConfig, error) {
 	if oidc != nil {
 		cfg.issuerURL = oidc.Key(issuerKey).String()
 		cfg.clientID = oidc.Key(clientIDKey).String()
+		cfg.clientSecret = oidc.Key(clientSecret).String()
 	}
 
 	users := iniCfg.Section(usersSection)

--- a/internal/broker/testdata/TestParseConfig/golden/do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
+++ b/internal/broker/testdata/TestParseConfig/golden/do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
@@ -1,4 +1,5 @@
 clientID=<CLIENT_ID
+clientSecret=
 issuerURL=https://ISSUER_URL>
 homeBaseDir=
 allowedSSHSuffixes=[]

--- a/internal/broker/testdata/TestParseConfig/golden/successfully_parse_config_file/config.txt
+++ b/internal/broker/testdata/TestParseConfig/golden/successfully_parse_config_file/config.txt
@@ -1,4 +1,5 @@
 clientID=client_id
+clientSecret=
 issuerURL=https://issuer.url.com
 homeBaseDir=
 allowedSSHSuffixes=[]

--- a/internal/broker/testdata/TestParseConfig/golden/successfully_parse_config_file_with_optional_values/config.txt
+++ b/internal/broker/testdata/TestParseConfig/golden/successfully_parse_config_file_with_optional_values/config.txt
@@ -1,4 +1,5 @@
 clientID=client_id
+clientSecret=
 issuerURL=https://issuer.url.com
 homeBaseDir=/home
 allowedSSHSuffixes=[]


### PR DESCRIPTION
Some providers, like google, request a client secret for the device authentication. Make it optional, so that the admin can set it if required in the generic broker.

There is no integration tests for now that could make use of it, but all existing tests are passing. I have also tested manually with google and msentraid.

UDENG-4954