### PR TITLE
Google provider

### DIFF
--- a/internal/providers/default.go
+++ b/internal/providers/default.go
@@ -1,4 +1,4 @@
-//go:build !withmsentraid
+//go:build !withgoogle && !withmsentraid
 
 package providers
 

--- a/internal/providers/google/google.go
+++ b/internal/providers/google/google.go
@@ -1,0 +1,28 @@
+// Package google is the google specific extension.
+package google
+
+import (
+	"github.com/ubuntu/authd-oidc-brokers/internal/providers/noprovider"
+)
+
+// Provider is the google provider implementation.
+type Provider struct {
+	noprovider.NoProvider
+}
+
+// New returns a new GoogleProvider.
+func New() Provider {
+	return Provider{
+		NoProvider: noprovider.New(),
+	}
+}
+
+// AdditionalScopes returns the generic scopes required by the provider.
+// Note that we do not return oidc.ScopeOfflineAccess, as for TV/limited input devices, the API call will fail as not
+// supported by this application type. However, the refresh token will be acquired and is functional to refresh without
+// user interaction.
+// If we start to support other kinds of applications, we should revisit this.
+// More info on https://developers.google.com/identity/protocols/oauth2/limited-input-device#allowedscopes.
+func (Provider) AdditionalScopes() []string {
+	return []string{}
+}

--- a/internal/providers/google/google_test.go
+++ b/internal/providers/google/google_test.go
@@ -1,0 +1,24 @@
+package google_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ubuntu/authd-oidc-brokers/internal/providers/google"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	p := google.New()
+
+	require.Empty(t, p, "New should return the default provider implementation with no parameters")
+}
+
+func TestAdditionalScopes(t *testing.T) {
+	t.Parallel()
+
+	p := google.New()
+
+	require.Empty(t, p.AdditionalScopes(), "Google provider should not require additional scopes")
+}

--- a/internal/providers/withgoogle.go
+++ b/internal/providers/withgoogle.go
@@ -1,0 +1,10 @@
+//go:build withgoogle
+
+package providers
+
+import "github.com/ubuntu/authd-oidc-brokers/internal/providers/google"
+
+// CurrentProviderInfo returns a Google provider implementation.
+func CurrentProviderInfo() ProviderInfoer {
+	return google.New()
+}


### PR DESCRIPTION
We need to override the generic provider to remove the offline_access scope. For TV and limited input devices apps, Google APIs will reject any request with this scope, while still allowing non interactive user access token refresh.
All the rest of the functionalities is aligned with the NoProvider one.
Added tests and "withgoogle" build tag for it.

UDENG-4953