### PR TITLE
config option to refer to the oidc configuration

### DIFF
--- a/cmd/authd-oidc/daemon/config.go
+++ b/cmd/authd-oidc/daemon/config.go
@@ -30,7 +30,7 @@ func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err err
 	setVerboseMode(v)
 
 	// Handle configuration.
-	if v, err := cmd.Flags().GetString("config"); err == nil && v != "" {
+	if v, err := cmd.Flags().GetString("paths-config"); err == nil && v != "" {
 		vip.SetConfigFile(v)
 	} else {
 		vip.SetConfigName(name)

--- a/cmd/authd-oidc/daemon/daemon.go
+++ b/cmd/authd-oidc/daemon/daemon.go
@@ -90,6 +90,8 @@ func New(name string) *App {
 
 	installVerbosityFlag(&a.rootCmd, a.viper)
 	installConfigFlag(&a.rootCmd)
+	// FIXME: This option is for the viper path configuration. We should merge --config and this one in the future.
+	a.rootCmd.PersistentFlags().StringP("paths-config", "", "", "use a specific paths configuration file")
 
 	// subcommands
 	a.installVersion()

--- a/cmd/authd-oidc/daemon/daemon.go
+++ b/cmd/authd-oidc/daemon/daemon.go
@@ -73,6 +73,11 @@ func New(name string) *App {
 				return fmt.Errorf("unable to decode configuration into struct: %w", err)
 			}
 
+			// FIXME: for now, config is only the broker.conf file. It should be merged with the viper configuration.
+			if v, err := cmd.Flags().GetString("config"); err == nil && v != "" {
+				a.config.Paths.BrokerConf = v
+			}
+
 			setVerboseMode(a.config.Verbosity)
 			slog.Debug("Debug mode is enabled")
 

--- a/cmd/authd-oidc/daemon/daemon_test.go
+++ b/cmd/authd-oidc/daemon/daemon_test.go
@@ -236,6 +236,38 @@ func TestConfigLoad(t *testing.T) {
 	require.Equal(t, config, a.Config(), "Config is loaded")
 }
 
+func TestConfigHasPrecedenceOverPathsConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	config := daemon.DaemonConfig{
+		Verbosity: 1,
+		Paths: daemon.SystemPaths{
+			BrokerConf: filepath.Join(tmpDir, "broker.conf"),
+			Cache:      filepath.Join(tmpDir, "cache"),
+		},
+	}
+
+	overrideBrokerConfPath := filepath.Join(tmpDir, "override", "via", "config", "broker.conf")
+	daemon.GenerateBrokerConfig(t, overrideBrokerConfPath, mockProvider.URL)
+	a := daemon.NewForTests(t, &config, mockProvider.URL, "--config", overrideBrokerConfPath)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := a.Run()
+		require.NoError(t, err, "Run should exits without any error")
+	}()
+	a.WaitReady()
+	time.Sleep(50 * time.Millisecond)
+
+	defer wg.Wait()
+	defer a.Quit()
+
+	want := config
+	want.Paths.BrokerConf = overrideBrokerConfPath
+	require.Equal(t, want, a.Config(), "Config is loaded")
+}
+
 func TestAutoDetectConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 	config := daemon.DaemonConfig{

--- a/cmd/authd-oidc/daemon/daemon_test.go
+++ b/cmd/authd-oidc/daemon/daemon_test.go
@@ -287,7 +287,7 @@ func TestNoConfigSetDefaults(t *testing.T) {
 
 func TestBadConfigReturnsError(t *testing.T) {
 	a := daemon.New(t.Name()) // Use version to still run preExec to load no config but without running server
-	a.SetArgs("version", "--config", "/does/not/exist.yaml")
+	a.SetArgs("version", "--paths-config", "/does/not/exist.yaml")
 
 	err := a.Run()
 	require.Error(t, err, "Run should return an error on config file")

--- a/cmd/authd-oidc/daemon/export_test.go
+++ b/cmd/authd-oidc/daemon/export_test.go
@@ -50,19 +50,7 @@ func GenerateTestConfig(t *testing.T, origConf *daemonConfig, providerURL string
 		conf.Paths.BrokerConf = filepath.Join(t.TempDir(), strings.ReplaceAll(t.Name(), "/", "_")+".yaml")
 	}
 
-	brokerCfg := fmt.Sprintf(`
-[authd]
-name = %[1]s
-brand_icon = broker_icon.png
-dbus_name = com.ubuntu.authd.%[1]s
-dbus_object = /com/ubuntu/authd/%[1]s
-
-[oidc]
-issuer = %[2]s
-client_id = client_id
-`, strings.ReplaceAll(t.Name(), "/", "_"), providerURL)
-	err := os.WriteFile(conf.Paths.BrokerConf, []byte(brokerCfg), 0600)
-	require.NoError(t, err, "Setup: could not create broker configuration for tests")
+	GenerateBrokerConfig(t, conf.Paths.BrokerConf, providerURL)
 
 	d, err := yaml.Marshal(conf)
 	require.NoError(t, err, "Setup: could not marshal configuration for tests")
@@ -72,6 +60,28 @@ client_id = client_id
 	require.NoError(t, err, "Setup: could not create configuration for tests")
 
 	return confPath
+}
+
+// GenerateBrokerConfig creates a broker configuration file for tests.
+func GenerateBrokerConfig(t *testing.T, p, providerURL string) {
+	t.Helper()
+
+	err := os.MkdirAll(filepath.Dir(p), 0700)
+	require.NoError(t, err, "Setup: could not create parent broker configuration directory for tests")
+
+	brokerCfg := fmt.Sprintf(`
+	[authd]
+	name = %[1]s
+	brand_icon = broker_icon.png
+	dbus_name = com.ubuntu.authd.%[1]s
+	dbus_object = /com/ubuntu/authd/%[1]s
+
+	[oidc]
+	issuer = %[2]s
+	client_id = client_id
+	`, strings.ReplaceAll(t.Name(), "/", "_"), providerURL)
+	err = os.WriteFile(p, []byte(brokerCfg), 0600)
+	require.NoError(t, err, "Setup: could not create broker configuration for tests")
 }
 
 // Config returns a DaemonConfig for tests.

--- a/cmd/authd-oidc/daemon/export_test.go
+++ b/cmd/authd-oidc/daemon/export_test.go
@@ -20,7 +20,7 @@ func NewForTests(t *testing.T, conf *DaemonConfig, providerURL string, args ...s
 	t.Helper()
 
 	p := GenerateTestConfig(t, conf, providerURL)
-	argsWithConf := []string{"--config", p}
+	argsWithConf := []string{"--paths-config", p}
 	argsWithConf = append(argsWithConf, args...)
 
 	a := New(t.Name())


### PR DESCRIPTION
We unfortunately have 2 configurations as I just noticed:
- one for the system paths + verbosity (the viper/daemon configuration)
- one for the oidc part.

--config was referring to the first one. This PR introduce --paths-config for the first one and --config is now targetting the second one, overriding this specific system path configuration for broker config.

Those 2 configurations should really be merged in a single file and let viper handling this. This would have the net benefit of supporting multiple configuration format too and remove a bunch of manual parsing. However, PR #134 has quite some configuration related changes already and that would conflict with it.

So, here, this change is to minimize the conflict with it, while still allowing being merged beforehand to unblock other teams.

A followup action (once the config change PR will be merged) will be on merging both and handling the parsing by viper, which should greatly simplify the overall structure.

UDENG-5083