### PR TITLE
Update golden files env var

### DIFF
--- a/cmd/authd-oidc/daemon/daemon_test.go
+++ b/cmd/authd-oidc/daemon/daemon_test.go
@@ -2,7 +2,6 @@ package daemon_test
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -407,14 +406,6 @@ func TestMain(m *testing.M) {
 	providerServer, cleanup := testutils.StartMockProvider("")
 	defer cleanup()
 	mockProvider = providerServer
-
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-	// Remove the flag from the command line arguments if it is present, to avoid that it's being parsed by the cobra
-	// command in the tests.
-	if testutils.Update() {
-		os.Args = os.Args[:len(os.Args)-1]
-	}
 
 	m.Run()
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -663,7 +663,7 @@ func TestIsAuthenticated(t *testing.T) {
 				}
 			}
 
-			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }
@@ -776,7 +776,7 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 					t.Logf("Failed to rename issuer data directory: %v", err)
 				}
 			}
-			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -2,7 +2,6 @@ package broker_test
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"net/http/httptest"
 	"os"
@@ -966,9 +965,6 @@ func TestUserPreCheck(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	testutils.InstallUpdateFlag()
-	flag.Parse()
-
 	server, cleanup := testutils.StartMockProvider("")
 	defer cleanup()
 

--- a/internal/broker/config_test.go
+++ b/internal/broker/config_test.go
@@ -106,7 +106,7 @@ func TestParseConfig(t *testing.T) {
 			err = os.WriteFile(filepath.Join(outDir, "config.txt"), []byte(strings.Join(fields, "\n")), 0600)
 			require.NoError(t, err)
 
-			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.Update())
+			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -127,7 +127,7 @@ func GoldenPath(t *testing.T) string {
 func CompareTreesWithFiltering(t *testing.T, p, goldPath string, update bool) {
 	t.Helper()
 
-	// Update golden file
+	// UpdateEnabled golden file
 	if update {
 		t.Logf("updating golden file %s", goldPath)
 		require.NoError(t, os.RemoveAll(goldPath), "Cannot remove target golden directory")
@@ -262,7 +262,7 @@ func addEmptyMarker(p string) error {
 	return err
 }
 
-// Update returns true if the update flag was set, false otherwise.
-func Update() bool {
+// UpdateEnabled returns true if the update flag was set, false otherwise.
+func UpdateEnabled() bool {
 	return update
 }

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -3,7 +3,6 @@ package testutils
 import (
 	"bytes"
 	"errors"
-	"flag"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -16,6 +15,18 @@ import (
 )
 
 var update bool
+
+const (
+	// UpdateGoldenFilesEnv is the environment variable used to indicate go test that
+	// the golden files should be overwritten with the current test results.
+	UpdateGoldenFilesEnv = `TESTS_UPDATE_GOLDEN`
+)
+
+func init() {
+	if os.Getenv(UpdateGoldenFilesEnv) != "" {
+		update = true
+	}
+}
 
 type goldenOptions struct {
 	goldenPath string
@@ -249,12 +260,6 @@ func addEmptyMarker(p string) error {
 	})
 
 	return err
-}
-
-// InstallUpdateFlag install an update flag referenced in this package.
-// The flags need to be parsed before running the tests.
-func InstallUpdateFlag() {
-	flag.BoolVar(&update, "update", false, "update golden files")
 }
 
 // Update returns true if the update flag was set, false otherwise.


### PR DESCRIPTION
Update golden files via the TESTS_UPDATE_GOLDEN env var
    
This allows us to update all golden files in one go, without having to
install the update flag per test package and deal with errors that the
flag is not supported in some packages.

Analogous to https://github.com/ubuntu/authd/pull/252.

UDENG-5173