### PR TITLE
Improve golden file error messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/microsoftgraph/msgraph-sdk-go v1.48.0
 	github.com/microsoftgraph/msgraph-sdk-go-core v1.2.1
 	github.com/otiai10/copy v1.14.0
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
@@ -48,7 +49,6 @@ require (
 	github.com/microsoft/kiota-serialization-text-go v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -668,7 +668,7 @@ func TestIsAuthenticated(t *testing.T) {
 				}
 			}
 
-			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
+			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }
@@ -794,7 +794,7 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 					t.Logf("Failed to rename issuer data directory: %v", err)
 				}
 			}
-			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
+			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -259,7 +259,7 @@ func TestGetAuthenticationModes(t *testing.T) {
 			}
 			require.NoError(t, err, "GetAuthenticationModes should not have returned an error")
 
-			testutils.CheckOrUpdateGoldenYAML(t, got, nil)
+			testutils.CheckOrUpdateGoldenYAML(t, got)
 		})
 	}
 }
@@ -374,7 +374,7 @@ func TestSelectAuthenticationMode(t *testing.T) {
 			}
 			require.NoError(t, err, "SelectAuthenticationMode should not have returned an error")
 
-			testutils.CheckOrUpdateGoldenYAML(t, got, nil)
+			testutils.CheckOrUpdateGoldenYAML(t, got)
 		})
 	}
 }
@@ -869,7 +869,7 @@ func TestFetchUserInfo(t *testing.T) {
 			}
 			require.NoError(t, err, "FetchUserInfo should not have returned an error")
 
-			testutils.CheckOrUpdateGoldenYAML(t, got, nil)
+			testutils.CheckOrUpdateGoldenYAML(t, got)
 		})
 	}
 }
@@ -973,7 +973,7 @@ func TestUserPreCheck(t *testing.T) {
 			}
 			require.NoError(t, err, "UserPreCheck should not have returned an error")
 
-			testutils.CheckOrUpdateGolden(t, got, nil)
+			testutils.CheckOrUpdateGolden(t, got)
 		})
 	}
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -668,7 +668,7 @@ func TestIsAuthenticated(t *testing.T) {
 				}
 			}
 
-			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
+			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t))
 		})
 	}
 }
@@ -794,7 +794,7 @@ func TestConcurrentIsAuthenticated(t *testing.T) {
 					t.Logf("Failed to rename issuer data directory: %v", err)
 				}
 			}
-			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
+			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t))
 		})
 	}
 }

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -259,8 +259,7 @@ func TestGetAuthenticationModes(t *testing.T) {
 			}
 			require.NoError(t, err, "GetAuthenticationModes should not have returned an error")
 
-			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
-			require.Equal(t, want, got, "GetAuthenticationModes should have returned the expected value")
+			testutils.CheckOrUpdateGoldenYAML(t, got, nil)
 		})
 	}
 }
@@ -375,8 +374,7 @@ func TestSelectAuthenticationMode(t *testing.T) {
 			}
 			require.NoError(t, err, "SelectAuthenticationMode should not have returned an error")
 
-			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
-			require.Equal(t, want, got, "SelectAuthenticationMode should have returned the expected layout")
+			testutils.CheckOrUpdateGoldenYAML(t, got, nil)
 		})
 	}
 }
@@ -871,8 +869,7 @@ func TestFetchUserInfo(t *testing.T) {
 			}
 			require.NoError(t, err, "FetchUserInfo should not have returned an error")
 
-			want := testutils.LoadWithUpdateFromGoldenYAML(t, got)
-			require.Equal(t, want, got, "FetchUserInfo should have returned the expected value")
+			testutils.CheckOrUpdateGoldenYAML(t, got, nil)
 		})
 	}
 }
@@ -976,8 +973,7 @@ func TestUserPreCheck(t *testing.T) {
 			}
 			require.NoError(t, err, "UserPreCheck should not have returned an error")
 
-			want := testutils.LoadWithUpdateFromGolden(t, got)
-			require.Equal(t, want, got, "UserPreCheck should have returned the expected value")
+			testutils.CheckOrUpdateGolden(t, got, nil)
 		})
 	}
 }

--- a/internal/broker/config_test.go
+++ b/internal/broker/config_test.go
@@ -106,7 +106,7 @@ func TestParseConfig(t *testing.T) {
 			err = os.WriteFile(filepath.Join(outDir, "config.txt"), []byte(strings.Join(fields, "\n")), 0600)
 			require.NoError(t, err)
 
-			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
+			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t))
 		})
 	}
 }

--- a/internal/broker/config_test.go
+++ b/internal/broker/config_test.go
@@ -106,7 +106,7 @@ func TestParseConfig(t *testing.T) {
 			err = os.WriteFile(filepath.Join(outDir, "config.txt"), []byte(strings.Join(fields, "\n")), 0600)
 			require.NoError(t, err)
 
-			testutils.CompareTreesWithFiltering(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
+			testutils.CheckOrUpdateGoldenFileTree(t, outDir, testutils.GoldenPath(t), testutils.UpdateEnabled())
 		})
 	}
 }

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -122,7 +122,6 @@ func GoldenPath(t *testing.T) string {
 }
 
 // CompareTreesWithFiltering allows comparing a goldPath directory to p. Those can be updated via the dedicated flag.
-// It will filter dconf database and not commit it in the new golden directory.
 func CompareTreesWithFiltering(t *testing.T, p, goldPath string, update bool) {
 	t.Helper()
 

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -122,10 +122,9 @@ func GoldenPath(t *testing.T) string {
 }
 
 // CheckOrUpdateGoldenFileTree allows comparing a goldPath directory to p. Those can be updated via the dedicated flag.
-func CheckOrUpdateGoldenFileTree(t *testing.T, p, goldPath string, update bool) {
+func CheckOrUpdateGoldenFileTree(t *testing.T, p, goldPath string) {
 	t.Helper()
 
-	// UpdateEnabled golden file
 	if update {
 		t.Logf("updating golden file %s", goldPath)
 		require.NoError(t, os.RemoveAll(goldPath), "Cannot remove target golden directory")

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -121,8 +121,8 @@ func GoldenPath(t *testing.T) string {
 	return path
 }
 
-// CompareTreesWithFiltering allows comparing a goldPath directory to p. Those can be updated via the dedicated flag.
-func CompareTreesWithFiltering(t *testing.T, p, goldPath string, update bool) {
+// CheckOrUpdateGoldenFileTree allows comparing a goldPath directory to p. Those can be updated via the dedicated flag.
+func CheckOrUpdateGoldenFileTree(t *testing.T, p, goldPath string, update bool) {
 	t.Helper()
 
 	// UpdateEnabled golden file

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -122,47 +122,47 @@ func GoldenPath(t *testing.T) string {
 }
 
 // CheckOrUpdateGoldenFileTree allows comparing a goldPath directory to p. Those can be updated via the dedicated flag.
-func CheckOrUpdateGoldenFileTree(t *testing.T, p, goldPath string) {
+func CheckOrUpdateGoldenFileTree(t *testing.T, path, goldenPath string) {
 	t.Helper()
 
 	if update {
-		t.Logf("updating golden file %s", goldPath)
-		err := os.RemoveAll(goldPath)
+		t.Logf("updating golden path %s", goldenPath)
+		err := os.RemoveAll(goldenPath)
 		require.NoError(t, err, "Cannot remove target golden directory")
 
 		// check the source directory exists before trying to copy it
-		info, err := os.Stat(p)
+		info, err := os.Stat(path)
 		if errors.Is(err, fs.ErrNotExist) {
 			return
 		}
-		require.NoErrorf(t, err, "Error on checking %q", p)
+		require.NoErrorf(t, err, "Error on checking %q", path)
 
 		if !info.IsDir() {
 			// copy file
-			data, err := os.ReadFile(p)
-			require.NoError(t, err, "Cannot read new generated file file %s", p)
-			err = os.WriteFile(goldPath, data, info.Mode())
+			data, err := os.ReadFile(path)
+			require.NoError(t, err, "Cannot read new generated file file %s", path)
+			err = os.WriteFile(goldenPath, data, info.Mode())
 			require.NoError(t, err, "Cannot write golden file")
 		} else {
-			err := addEmptyMarker(p)
-			require.NoError(t, err, "Cannot add empty marker to directory %s", p)
+			err := addEmptyMarker(path)
+			require.NoError(t, err, "Cannot add empty marker to directory %s", path)
 
-			err = cp.Copy(p, goldPath)
+			err = cp.Copy(path, goldenPath)
 			require.NoError(t, err, "Can’t update golden directory")
 		}
 	}
 
 	var gotContent map[string]treeAttrs
-	if _, err := os.Stat(p); err == nil {
-		gotContent, err = treeContentAndAttrs(t, p, nil)
+	if _, err := os.Stat(path); err == nil {
+		gotContent, err = treeContentAndAttrs(t, path, nil)
 		if err != nil {
 			t.Fatalf("No generated content: %v", err)
 		}
 	}
 
 	var goldContent map[string]treeAttrs
-	if _, err := os.Stat(goldPath); err == nil {
-		goldContent, err = treeContentAndAttrs(t, goldPath, nil)
+	if _, err := os.Stat(goldenPath); err == nil {
+		goldContent, err = treeContentAndAttrs(t, goldenPath, nil)
 		if err != nil {
 			t.Fatalf("No golden directory found: %v", err)
 		}
@@ -175,8 +175,8 @@ func CheckOrUpdateGoldenFileTree(t *testing.T, p, goldPath string) {
 	}
 	require.Empty(t, gotContent, "Some files are missing in the golden directory")
 
-	// No more verification on p if it doesn’t exists
-	if _, err := os.Stat(p); errors.Is(err, fs.ErrNotExist) {
+	// No more verification on path if it doesn’t exists
+	if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
 		return
 	}
 }

--- a/internal/testutils/golden.go
+++ b/internal/testutils/golden.go
@@ -127,7 +127,8 @@ func CheckOrUpdateGoldenFileTree(t *testing.T, p, goldPath string) {
 
 	if update {
 		t.Logf("updating golden file %s", goldPath)
-		require.NoError(t, os.RemoveAll(goldPath), "Cannot remove target golden directory")
+		err := os.RemoveAll(goldPath)
+		require.NoError(t, err, "Cannot remove target golden directory")
 
 		// check the source directory exists before trying to copy it
 		info, err := os.Stat(p)
@@ -140,7 +141,8 @@ func CheckOrUpdateGoldenFileTree(t *testing.T, p, goldPath string) {
 			// copy file
 			data, err := os.ReadFile(p)
 			require.NoError(t, err, "Cannot read new generated file file %s", p)
-			require.NoError(t, os.WriteFile(goldPath, data, info.Mode()), "Cannot write golden file")
+			err = os.WriteFile(goldPath, data, info.Mode())
+			require.NoError(t, err, "Cannot write golden file")
 		} else {
 			err := addEmptyMarker(p)
 			require.NoError(t, err, "Cannot add empty marker to directory %s", p)


### PR DESCRIPTION
UDENG-5195

This changes the error message from:

```
Error:      	Not equal: 
expected: map[string]string{"button":"Request new login code", "code":"user_code", "content":"https://verification_uri.com", "foo":"bar", "label":"Scan the QR code or access \"https://verification_uri.com\" and use the provided login code", "type":"qrcode", "wait":"true"}
actual  : map[string]string{"button":"Request new login code", "code":"user_code", "content":"https://verification_uri.com", "label":"Scan the QR code or access \"https://verification_uri.com\" and use the provided login code", "type":"qrcode", "wait":"true"}

Diff:
--- Expected
+++ Actual
@@ -1,2 +1,2 @@
-(map[string]string) (len=7) {
+(map[string]string) (len=6) {
  (string) (len=6) "button": (string) (len=22) "Request new login code",
@@ -4,3 +4,2 @@
  (string) (len=7) "content": (string) (len=28) "https://verification_uri.com",
- (string) (len=3) "foo": (string) (len=3) "bar",
  (string) (len=5) "label": (string) (len=89) "Scan the QR code or access \"https://verification_uri.com\" and use the provided login code",
Test:       	TestSelectAuthenticationMode/Successfully_select_device_auth_qr
Messages:   	SelectAuthenticationMode should have returned the expected layout
```

to 

```
Error:      	Golden file content mismatch

Expected (golden):
--------------------------------------------------
button: Request new login code
code: user_code
content: https://verification_uri.com
label: Scan the QR code or access "https://verification_uri.com" and use the provided login code
type: qrcode
wait: "true"
foo: bar
--------------------------------------------------

Actual: 
--------------------------------------------------
button: Request new login code
code: user_code
content: https://verification_uri.com
label: Scan the QR code or access "https://verification_uri.com" and use the provided login code
type: qrcode
wait: "true"
--------------------------------------------------

Diff:
--- Expected (golden)
+++ Actual
@@ -4,5 +4,4 @@
 label: Scan the QR code or access "https://verification_uri.com" and use the provided login code
 type: qrcode
 wait: "true"
-foo: bar
 
Test:       	TestSelectAuthenticationMode/Successfully_select_device_auth_qr
Messages:   	Golden file: testdata/TestSelectAuthenticationMode/golden/Successfully_select_device_auth_qr
```

If [`delta`](https://github.com/dandavison/delta) is installed on the system, the diff is also colorized:

![image](https://github.com/user-attachments/assets/e0b7aadd-79ea-4650-b2d0-1842c147399e)