### PR TITLE
fix(dbusservice): Use array of strings maps arguments types for GetAuthenticationModes

### DIFF
--- a/internal/dbusservice/dbusservice.go
+++ b/internal/dbusservice/dbusservice.go
@@ -15,16 +15,16 @@ const intro = `
 <node>
 	<interface name="%s">
 		<method name="NewSession">
-		<arg type="s" direction="in" name="username"/>
-		<arg type="s" direction="in" name="lang"/>
-		<arg type="s" direction="in" name="mode"/>
-		<arg type="s" direction="out" name="sessionID"/>
-		<arg type="s" direction="out" name="encryptionKey"/>
+			<arg type="s" direction="in" name="username"/>
+			<arg type="s" direction="in" name="lang"/>
+			<arg type="s" direction="in" name="mode"/>
+			<arg type="s" direction="out" name="sessionID"/>
+			<arg type="s" direction="out" name="encryptionKey"/>
 		</method>
 		<method name="GetAuthenticationModes">
-		<arg type="s" direction="in" name="sessionID"/>
-		<arg type="a{ss}" direction="in" name="supportedUILayouts"/>
-		<arg type="a{ss}" direction="out" name="authenticationModes"/>
+			<arg type="s" direction="in" name="sessionID"/>
+			<arg type="a{ss}" direction="in" name="supportedUILayouts"/>
+			<arg type="a{ss}" direction="out" name="authenticationModes"/>
 		</method>
 		<method name="SelectAuthenticationMode">
 			<arg type="s" direction="in" name="sessionID"/>

--- a/internal/dbusservice/dbusservice.go
+++ b/internal/dbusservice/dbusservice.go
@@ -23,8 +23,8 @@ const intro = `
 		</method>
 		<method name="GetAuthenticationModes">
 			<arg type="s" direction="in" name="sessionID"/>
-			<arg type="a{ss}" direction="in" name="supportedUILayouts"/>
-			<arg type="a{ss}" direction="out" name="authenticationModes"/>
+			<arg type="aa{ss}" direction="in" name="supportedUILayouts"/>
+			<arg type="aa{ss}" direction="out" name="authenticationModes"/>
 		</method>
 		<method name="SelectAuthenticationMode">
 			<arg type="s" direction="in" name="sessionID"/>


### PR DESCRIPTION
The method accepts a slice of maps and returns another slice of maps, so
we should respect that in the introspection data

UDENG-5321

Related to https://github.com/ubuntu/authd/issues/628