### PR TITLE
fix client authn request parameter name

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -363,6 +363,9 @@ func (b *Broker) generateUILayout(session *session, authModeID string) (map[stri
 		// oauth2 lib.
 		// Some providers support both of these authentication methods, some implement only one and
 		// some implement neither.
+		// This was tested with the following providers:
+		// - Google: supports client_secret_post
+		// - Ory Hydra: supports client_secret_post
 		// TODO @shipperizer: client_authentication methods should be configurable
 		if secret := session.oauth2Config.ClientSecret; secret != "" {
 			authOpts = append(authOpts, oauth2.SetAuthURLParam("client_secret", secret))


### PR DESCRIPTION
The previous [PR](https://github.com/ubuntu/authd-oidc-brokers/pull/216) had a typo. I tested it against a generic OIDC provider and it now works. 

Disclaimer: This logic works for only 1 (`client_secret_post`) out of the 2 most common client authentication methods (for a list of all the client authn methods see [here](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)). I am not sure if there is a way to make it work for any of the other methods using the std go oauth2 lib.