### PR TITLE
Fix spelling in config file

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -11,6 +11,6 @@ client_id = <CLIENT_ID>
 # The user home directory will be created in the format of {home_base_dir}/{username}
 # home_base_dir = /home
 
-# The username suffixes that are allowed to log in via ssh without existing previously in the system.
+# The username suffixes that are allowed to log in via SSH without existing previously in the system.
 # The suffixes must be separated by commas.
 # ssh_allowed_suffixes = @example.com,@anotherexample.com

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -11,6 +11,6 @@ client_id = <CLIENT_ID>
 # The user home directory will be created in the format of {home_base_dir}/{username}
 # home_base_dir = /home
 
-# The username suffixes that are allowed to login via ssh without existing previously in the system.
+# The username suffixes that are allowed to log in via ssh without existing previously in the system.
 # The suffixes must be separated by commas.
 # ssh_allowed_suffixes = @example.com,@anotherexample.com


### PR DESCRIPTION
* "login" is the noun, "log in" is the verb
* Write "SSH" instead of "ssh"