### PR TITLE
Remove incorrect os.Exit(m.Run()) calls

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -1011,5 +1011,5 @@ func TestMain(m *testing.M) {
 	defaultIssuerURL, cleanup = testutils.StartMockProviderServer("", nil)
 	defer cleanup()
 
-	os.Exit(m.Run())
+	m.Run()
 }


### PR DESCRIPTION
This is not needed since Go 1.15, where the test runtime registers the test result itself.
Also, os.Exit() would skip any defer() being called before, which might pollute the system running the tests.

UDENG-5633