### PR TITLE
Ensure broker.conf has permissions 0600

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 set -eu
 
-cp --update=none ${SNAP}/conf/broker.conf.orig ${SNAP_DATA}/broker.conf
+install --mode=0600 "${SNAP}/conf/broker.conf.orig" "${SNAP_DATA}/broker.conf"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+# In previous versions, the broker.conf was created with mode 0777 - umask.
+# This is not secure, because the file can contain sensitive information
+# (like the client_secret), so we ensure that the mode is 0700.
+if [ -f "${SNAP_DATA}/broker.conf" ]; then
+  chmod 0600 "${SNAP_DATA}/broker.conf"
+fi


### PR DESCRIPTION
In previous versions, the broker.conf was created with mode 0666 - umask. This is not secure, because the file can contain sensitive information (like the client_secret), so we ensure that the mode is 0600.