### PR TITLE
Build google snap broker

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -18,7 +18,7 @@ jobs:
     name: Update snap branches
     strategy:
       matrix:
-        branch_name: ["msentraid"]
+        branch_name: ["google", "msentraid"]
     runs-on: ubuntu-latest
     steps:
         - name: Install dependencies

--- a/conf/authd.conf
+++ b/conf/authd.conf
@@ -1,7 +1,7 @@
 # This section is used by authd to identify and communicate with the broker.
 # It should not be edited.
 [authd]
-name = OIDC
-brand_icon = /snap/authd-oidc/current/broker_icon.png
-dbus_name = com.ubuntu.authd.Oidc
-dbus_object = /com/ubuntu/authd/Oidc
+name = Google
+brand_icon = /snap/authd-google/current/broker_icon.png
+dbus_name = com.ubuntu.authd.Google
+dbus_object = /com/ubuntu/authd/Google

--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -1,10 +1,7 @@
 [oidc]
-issuer = https://<ISSUER_URL>
+issuer = https://accounts.google.com
 client_id = <CLIENT_ID>
-
-## Depending on the identity provider, you may need to provide a
-## client secret to authenticate with the provider.
-#client_secret = <CLIENT_SECRET>
+client_secret = <CLIENT_SECRET>
 
 [users]
 ## The directory where the home directories of new users are created.

--- a/internal/consts/authd.go
+++ b/internal/consts/authd.go
@@ -5,7 +5,7 @@ package consts
 //go:generate go run generate.go
 const (
 	// DbusName owned by the broker for authd to contact us.
-	DbusName = "com.ubuntu.authd.Oidc"
+	DbusName = "com.ubuntu.authd.Google"
 	// DbusObject main object path for authd to contact us.
-	DbusObject = "/com/ubuntu/authd/Oidc"
+	DbusObject = "/com/ubuntu/authd/Google"
 )

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -10,7 +10,8 @@ if [ -f "${SNAP_DATA}/broker.conf" ]; then
 fi
 
 PREVIOUS_VERSION=$(snapctl get previous-version)
-INITIAL_ALLOWED_USERS_VERSION="0.2.0"
+# For Google, we are directly starting shipping 0.2.0 files. Bump on first transition.
+INITIAL_ALLOWED_USERS_VERSION="0.0.0"
 
 log() {
   logger -t "${SNAP_NAME}" "post-refresh: $*"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
-name: authd-oidc
-summary: OIDC Broker for authd
+name: authd-google
+summary: Google Broker for authd
 description: |
-  Broker that enables OIDC authentication for authd.
+  Broker that enables OIDC authentication with Google for authd.
 adopt-info: version
 grade: stable
 base: core24
@@ -9,8 +9,8 @@ confinement: strict
 license: GPL-3.0
 
 apps:
-  authd-oidc:
-    command: bin/authd-oidc
+  authd-google:
+    command: bin/authd-google
     daemon: simple
     slots:
       - dbus-authd
@@ -22,21 +22,25 @@ slots:
   dbus-authd:
     interface: dbus
     bus: system
-    name: com.ubuntu.authd.Oidc
+    name: com.ubuntu.authd.Google
 
 parts:
   broker:
     source: .
     source-type: local
     plugin: go
+    go-buildtags: [withgoogle]
     build-snaps:
       - go
+    override-build: |
+      go mod download all
+      go build -tags=withgoogle -o ${GOBIN}/authd-google ./cmd/authd-oidc
   config:
     source: conf/
     source-type: local
     plugin: dump
     organize:
-      "authd.conf": "conf/authd/oidc.conf"
+      "authd.conf": "conf/authd/google.conf"
       "broker.conf": "conf/broker.conf.orig"
       "migrations": "conf/migrations"
   # Build the snap version from the git repository and current tree state.


### PR DESCRIPTION
Set a first set of Google broker build and configuration. Reserve its own dbus name. Note that client_secret is mandated when referring a google application using that keyboard-less flavor.

Disable the uneeded ownership migration for that branch: as we already ship the device ownership from its first version and don’t want to version this separately, disable shipping the migration file on first run and prevent for future migration file possible stamping.
The migration file creation will need to be reworked to be more future-proof compatible as only one level of migration is addressable right now.

Ensure auto-CI branch update points to the Google branch too.

UDENG-5622
