### PR TITLE
Use the msgraph host from the OpenID provider metadata

### DIFF
--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -28,7 +28,11 @@ func init() {
 	pp.ColoringEnabled = false
 }
 
-const localGroupPrefix = "linux-"
+const (
+	localGroupPrefix   = "linux-"
+	defaultMSGraphHost = "graph.microsoft.com"
+	msgraphAPIVersion  = "v1.0"
+)
 
 // Provider is the Microsoft Entra ID provider implementation.
 type Provider struct {
@@ -86,14 +90,34 @@ func (p Provider) GetExtraFields(token *oauth2.Token) map[string]interface{} {
 	}
 }
 
+// GetMetadata returns relevant metadata about the provider.
+func (p Provider) GetMetadata(provider *oidc.Provider) (map[string]interface{}, error) {
+	var claims struct {
+		MSGraphHost string `json:"msgraph_host"`
+	}
+
+	if err := provider.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("failed to get provider claims: %v", err)
+	}
+
+	return map[string]interface{}{
+		"msgraph_host": claims.MSGraphHost,
+	}, nil
+}
+
 // GetUserInfo is a no-op when no specific provider is in use.
-func (p Provider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error) {
+func (p Provider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken, providerMetadata map[string]interface{}) (info.User, error) {
+	msgraphHost := providerMetadata["msgraph_host"]
+	if msgraphHost == nil {
+		msgraphHost = defaultMSGraphHost
+	}
+
 	userClaims, err := p.userClaims(idToken)
 	if err != nil {
 		return info.User{}, err
 	}
 
-	userGroups, err := p.getGroups(accessToken)
+	userGroups, err := p.getGroups(accessToken, msgraphHost.(string))
 	if err != nil {
 		return info.User{}, err
 	}
@@ -126,7 +150,7 @@ func (p Provider) userClaims(idToken *oidc.IDToken) (claims, error) {
 }
 
 // getGroups access the Microsoft Graph API to get the groups the user is a member of.
-func (p Provider) getGroups(token *oauth2.Token) ([]info.Group, error) {
+func (p Provider) getGroups(token *oauth2.Token, msgraphHost string) ([]info.Group, error) {
 	slog.Debug("Getting user groups from Microsoft Graph API")
 
 	// Check if the token has the GroupMember.Read.All scope
@@ -148,6 +172,7 @@ func (p Provider) getGroups(token *oauth2.Token) ([]info.Group, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create GraphRequestAdapter: %v", err)
 	}
+	adapter.SetBaseUrl(fmt.Sprintf("https://%s/%s", msgraphHost, msgraphAPIVersion))
 
 	client := msgraphsdk.NewGraphServiceClient(adapter)
 

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -105,7 +105,8 @@ func (p Provider) GetMetadata(provider *oidc.Provider) (map[string]interface{}, 
 	}, nil
 }
 
-// GetUserInfo is a no-op when no specific provider is in use.
+// GetUserInfo returns the user info from the ID token and the groups the user is a member of, which are retrieved via
+// the Microsoft Graph API.
 func (p Provider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken, providerMetadata map[string]interface{}) (info.User, error) {
 	msgraphHost := providerMetadata["msgraph_host"]
 	if msgraphHost == nil {

--- a/internal/providers/noprovider/noprovider.go
+++ b/internal/providers/noprovider/noprovider.go
@@ -84,8 +84,13 @@ func (p NoProvider) GetExtraFields(token *oauth2.Token) map[string]interface{} {
 	return nil
 }
 
+// GetMetadata is a no-op when no specific provider is in use.
+func (p NoProvider) GetMetadata(provider *oidc.Provider) (map[string]interface{}, error) {
+	return nil, nil
+}
+
 // GetUserInfo is a no-op when no specific provider is in use.
-func (p NoProvider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error) {
+func (p NoProvider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken, providerMetadata map[string]interface{}) (info.User, error) {
 	userClaims, err := p.userClaims(idToken)
 	if err != nil {
 		return info.User{}, err

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -23,7 +23,8 @@ type Provider interface {
 		currentAuthStep int,
 	) ([]string, error)
 	GetExtraFields(token *oauth2.Token) map[string]interface{}
-	GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error)
+	GetMetadata(provider *oidc.Provider) (map[string]interface{}, error)
+	GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken, providerMetadata map[string]interface{}) (info.User, error)
 	NormalizeUsername(username string) string
 	VerifyUsername(requestedUsername, authenticatedUsername string) error
 }

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -378,8 +378,13 @@ func (p *MockProvider) NormalizeUsername(username string) string {
 	return strings.ToLower(username)
 }
 
+// GetMetadata is a no-op when no specific provider is in use.
+func (p *MockProvider) GetMetadata(provider *oidc.Provider) (map[string]interface{}, error) {
+	return nil, nil
+}
+
 // GetUserInfo is a no-op when no specific provider is in use.
-func (p *MockProvider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken) (info.User, error) {
+func (p *MockProvider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken, providerMetadata map[string]interface{}) (info.User, error) {
 	if p.GetUserInfoFails {
 		return info.User{}, errors.New("error requested in the mock")
 	}

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -14,10 +14,11 @@ import (
 
 // AuthCachedInfo represents the token that will be saved on disk for offline authentication.
 type AuthCachedInfo struct {
-	Token       *oauth2.Token
-	ExtraFields map[string]interface{}
-	RawIDToken  string
-	UserInfo    info.User
+	Token            *oauth2.Token
+	ExtraFields      map[string]interface{}
+	RawIDToken       string
+	ProviderMetadata map[string]interface{}
+	UserInfo         info.User
 }
 
 // NewAuthCachedInfo creates a new AuthCachedInfo. It sets the provided token and rawIDToken and the provider-specific


### PR DESCRIPTION
GCC High tenants use a different msgraph host. The hostname is part of the provider metadata that's retrieved during OpenID Connect Discovery via the `.well-known/openid-configuration` path.

This commit uses that hostname from the retrieved provider metadata in order to support GCC High tenants.

Closes https://github.com/ubuntu/authd/issues/708
UDENG-5709