### PR TITLE
Fix snap install hook

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,4 +2,4 @@
 
 set -eu
 
-install --mode=0700 "${SNAP}/conf/broker.conf.orig" "${SNAP_DATA}/broker.conf"
+install --mode=0600 "${SNAP}/conf/broker.conf.orig" "${SNAP_DATA}/broker.conf"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,4 +2,5 @@
 
 set -eu
 
-install --mode=0600 "${SNAP}/conf/broker.conf.orig" "${SNAP_DATA}/broker.conf"
+cp --update=none "${SNAP}/conf/broker.conf.orig" "${SNAP_DATA}/broker.conf"
+chmod 0600 "${SNAP_DATA}/broker.conf"


### PR DESCRIPTION
* Create `broker.conf` with permissions 0600
* Fix installation of snap failing with "install: Permission denied"

Closes https://github.com/ubuntu/authd/issues/716
UDENG-5713