### PR TITLE
Hide --config flag

### DIFF
--- a/cmd/authd-oidc/daemon/config.go
+++ b/cmd/authd-oidc/daemon/config.go
@@ -82,7 +82,11 @@ func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err err
 
 // installConfigFlag installs a --config option.
 func installConfigFlag(cmd *cobra.Command) *string {
-	return cmd.PersistentFlags().StringP("config", "c", "", "use a specific configuration file")
+	flag := cmd.PersistentFlags().StringP("config", "c", "", "use a specific configuration file")
+	if err := cmd.PersistentFlags().MarkHidden("config"); err != nil {
+		slog.Warn(fmt.Sprintf("Failed to hide --config flag: %v", err))
+	}
+	return flag
 }
 
 // SetVerboseMode change ErrorFormat and logs between very, middly and non verbose.

--- a/cmd/authd-oidc/daemon/daemon.go
+++ b/cmd/authd-oidc/daemon/daemon.go
@@ -106,6 +106,9 @@ func New(name string) *App {
 	installConfigFlag(&a.rootCmd)
 	// FIXME: This option is for the viper path configuration. We should merge --config and this one in the future.
 	a.rootCmd.PersistentFlags().StringP("paths-config", "", "", "use a specific paths configuration file")
+	if err := a.rootCmd.PersistentFlags().MarkHidden("paths-config"); err != nil {
+		slog.Warn(fmt.Sprintf("Failed to hide --paths-config flag: %v", err))
+	}
 
 	// subcommands
 	a.installVersion()


### PR DESCRIPTION
With 7a4d98054cb7d3d719e3a6f0700ccb6dc67e69b6, we automatically generate config files in the `.d` directory of the config file. We don't want to create those in `$PWD/mybroker.conf.d` when `--config mybroker.conf` is used.  

To avoid additional complexity, we decided to keep the current behavior but hide the flag from the usage message, so that it's only used for debugging and testing.  

Also hide the --paths-config flag for the same reason.

UDENG-5653