### PR TITLE
Correctly handle pre-release versions in post-refresh hook

### DIFF
--- a/snap/get_version
+++ b/snap/get_version
@@ -5,8 +5,8 @@ set -eu
 
 # When considering a tag, if starting with "<current branch name>-" it will have its prefix removed.
 # For instance:
-# * 0.1 -> 0.1
-# * msentraid-0.1 -> 0.1 on msentraid branch.
+# * 0.1.0 -> 0.1.0
+# * msentraid-0.1.0 -> 0.1.0 on msentraid branch.
 
 # 1. If current commit is tagged, the version is directly the tag name.
 # 2. If current commit is not tagged, the version is:

--- a/snap/get_version
+++ b/snap/get_version
@@ -13,7 +13,7 @@ set -eu
 #    a. <last tag name on current branch>+<commit_sha> for main branch.
 #    b. <last tag name on current branch (not in main)>+<commit_sha>.<last_commit_merged_from_main> for other branches.
 #
-# Any of those version will be annoted with +dirty if there are local changes.
+# Any of those version will be annoted with .dirty if there are local changes.
 
 # set_version will markup the version in the snapcraft.yaml file after amending it with a dirty markup if necessary.
 # $1: version: the version to set.
@@ -32,7 +32,7 @@ annotate_with_dirty() {
     # check if current tree content is dirty.
     is_dirty=$(git -C "${SNAPCRAFT_PART_SRC}" status --porcelain)
     if [ -n "${is_dirty}" ]; then
-        version="${version}+dirty"
+        version="${version}.dirty"
     fi
 
     echo "${version}"

--- a/snap/get_version
+++ b/snap/get_version
@@ -88,4 +88,10 @@ last_commit_on_main=$(git -C "${SNAPCRAFT_PART_SRC}" merge-base main HEAD)
 last_commit_on_main=$(git -C "${SNAPCRAFT_PART_SRC}" rev-parse --short=7 "${last_commit_on_main}")
 version="${version}.${last_commit_on_main}"
 
+# Check if the version is a valid semantic version.
+if ! semver check "${version}"; then
+    echo "Version ${version} is not a valid semantic version."
+    exit 1
+fi
+
 set_version "${version}"

--- a/snap/get_version
+++ b/snap/get_version
@@ -75,7 +75,7 @@ if [ -n "${tag}" ] && [ "$(git describe --tags --exact-match 2>/dev/null)" = "${
 fi
 
 # Current commit is not tagged, append commit(s) sha.
-version="${version}+$(git -C ${SNAPCRAFT_PART_SRC} rev-parse --short=7 HEAD)"
+version="${version}+$(git -C "${SNAPCRAFT_PART_SRC}" rev-parse --short=7 HEAD)"
 
 # Main branch will be set as is.
 if [ "${current_branch}" = "main" ]; then

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -4,7 +4,7 @@ set -eu
 
 # In previous versions, the broker.conf was created with mode 0777 - umask.
 # This is not secure, because the file can contain sensitive information
-# (like the client_secret), so we ensure that the mode is 0700.
+# (like the client_secret), so we ensure that the mode is 0600.
 if [ -f "${SNAP_DATA}/broker.conf" ]; then
   chmod 0600 "${SNAP_DATA}/broker.conf"
 fi

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -17,7 +17,8 @@ log() {
 }
 
 version_less_than() {
-  [ "$1" = "$2" ] && return 1 || [ "$(printf '%s\n' "${@}" | sort -V | head -n1)" = "$1" ]
+  output=$(semver compare "$1" "$2") || exit 1
+  [ "${output}" = "less" ]
 }
 
 should_transition_to_allowed_users() {

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -21,7 +21,24 @@ version_less_than() {
   [ "${output}" = "less" ]
 }
 
+valid_semver() {
+  output=$(semver check "$1")
+  if [ "$?" -ne 0 ] && [ "${output}" != "invalid" ]; then
+    exit 1
+  fi
+  [ "${output}" = "valid" ]
+}
+
 should_transition_to_allowed_users() {
+  # Do not transition if the previous version is set but not a valid
+  # semantic version. That's the case for snaps published to the edge
+  # channel before the 0.2.0 release, which already ship the allowed users
+  # configuration.
+  # TODO: We can remove this check once all users have updated to 0.2.0.
+  if [ -n "${PREVIOUS_VERSION}" ] && ! valid_semver "${PREVIOUS_VERSION}"; then
+    return 1
+  fi
+
   # Transition to allowed users if:
   # - previous-version is not set (that means that the previous version is
   #   older than 0.2.0, i.e. the version where we introduced setting the

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -10,7 +10,7 @@ if [ -f "${SNAP_DATA}/broker.conf" ]; then
 fi
 
 PREVIOUS_VERSION=$(snapctl get previous-version)
-INITIAL_ALLOWED_USERS_VERSION="0.2.0"
+INITIAL_ALLOWED_USERS_VERSION="0.2.0-pre1"
 
 log() {
   logger -t "${SNAP_NAME}" "post-refresh: $*"

--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -10,6 +10,11 @@ if [ -f "${SNAP_DATA}/broker.conf" ]; then
 fi
 
 PREVIOUS_VERSION=$(snapctl get previous-version)
+
+# Important: If you add new migrations, make sure to tag the commit which
+# first introduces the change, so that pre-release versions which already
+# contain the change (and which automatically uploaded to the edge channel)
+# will not be migrated.
 INITIAL_ALLOWED_USERS_VERSION="0.2.0-pre1"
 
 log() {

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,14 @@ parts:
       "authd.conf": "conf/authd/oidc.conf"
       "broker.conf": "conf/broker.conf.orig"
       "migrations": "conf/migrations"
+  # SemVer comparison helper
+  semver:
+    source: tools
+    source-type: local
+    plugin: go
+    override-build: |
+      go mod download all
+      go build -o ${GOBIN}/semver semver/semver.go
   # Build the snap version from the git repository and current tree state.
   version:
     source: .
@@ -46,3 +54,5 @@ parts:
     build-packages:
       - git # The script needs Git.
     override-build: ./snap/get_version
+    after:
+      - semver

--- a/tools/semver/semver.go
+++ b/tools/semver/semver.go
@@ -1,0 +1,89 @@
+// Package semver implements comparison of semantic version strings.
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "check":
+		if len(os.Args) != 3 {
+			fmt.Fprintf(os.Stderr, "Error: 'check' requires exactly one version argument\n")
+			usage()
+			os.Exit(1)
+		}
+		checkVersion(os.Args[2])
+
+	case "compare":
+		if len(os.Args) != 4 {
+			fmt.Fprintf(os.Stderr, "Error: 'compare' requires exactly two version arguments\n")
+			usage()
+			os.Exit(1)
+		}
+		compareVersions(os.Args[2], os.Args[3])
+
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown command %q\n", os.Args[1])
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage: %[1]s <command> [arguments]
+
+Commands:
+  check <version>           Check if a version is valid
+  compare <ver1> <ver2>     Compare two versions
+
+Examples:
+  %[1]s check 1.2.3           # Prints "valid" or "invalid"
+  %[1]s compare 1.2.3 2.0.0   # Prints "less", "equal", or "greater"
+`, os.Args[0])
+}
+
+func addVPrefix(version string) string {
+	if !strings.HasPrefix(version, "v") {
+		return "v" + version
+	}
+	return version
+}
+
+func checkVersion(version string) {
+	v := addVPrefix(version)
+	if semver.IsValid(v) {
+		fmt.Println("valid")
+		return
+	}
+	fmt.Println("invalid")
+	os.Exit(1)
+}
+
+func compareVersions(ver1, ver2 string) {
+	v1 := addVPrefix(ver1)
+	v2 := addVPrefix(ver2)
+
+	if !semver.IsValid(v1) || !semver.IsValid(v2) {
+		fmt.Fprintf(os.Stderr, "Error: invalid semantic version format\n")
+		os.Exit(1)
+	}
+
+	switch semver.Compare(v1, v2) {
+	case -1:
+		fmt.Println("less")
+	case 0:
+		fmt.Println("equal")
+	case 1:
+		fmt.Println("greater")
+	}
+}


### PR DESCRIPTION
* Use SemVer versions
  * Separate the "dirty" annotation with a . instead of +
  * Versions must now have a patch version
*  Make the version comparison in the post-refresh hook SemVer compatible, so that 0.2.0-pre1 is considered lower than 0.2.0
* Set INITIAL_ALLOWED_USERS_VERSION="0.2.0-pre1" in the post-refresh hook
* Add special handling for the pre-release versions which were uploaded to the edge channels and already contain the allowed users config

UDENG-5714

TODO:
* [ ] Tag the commit "Set INITIAL_ALLOWED_USERS_VERSION to 0.2.0-pre1" with `0.2.0-pre1` after this has been merged to main
* [ ] Tag the same commit on the `msentraid` branch
* [ ] Tag the same commit on the `google` branch