### PR TITLE
Support showing INFO messages without DEBUG messages

### DIFF
--- a/cmd/authd-oidc/daemon/config.go
+++ b/cmd/authd-oidc/daemon/config.go
@@ -96,7 +96,7 @@ func setVerboseMode(level int) {
 	case 0:
 		log.SetLevel(consts.DefaultLevelLog)
 	case 1:
-		log.SetLevel(slog.LevelDebug)
+		log.SetLevel(slog.LevelInfo)
 	case 3:
 		//reportCaller = true
 		fallthrough


### PR DESCRIPTION
Currently, we only show WARN messages when verbose mode is disabled, and when there's at least one "-v" flag, we show both INFO and DEBUG messages.

With this commit, we change that behavior to the same as authd: When there is one "-v" flag, we show INFO messages, when there's at least two, we also show DEBUG messages.