### PR TITLE
ci: Install git-delta for nicer diffs in error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Install dependencies
+        run: |
+          set -eu
+          sudo apt update
+          sudo apt install -y git-delta
+
       - name: Prepare tests artifacts path
         run: |
           set -eu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
   go-tests:
     name: "Go: Tests"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04 # ubuntu-latest-runner
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
The diffs of mismatching golden files are passed through git-delta since https://github.com/ubuntu/authd-oidc-brokers/pull/207.

Also makes the test run on on Noble instead of Jammy, because git-delta is not packaged in Jammy.