### PR TITLE
Avoid repetition in syslog identifier (msentraid)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ apps:
     plugs:
       - network
     restart-condition: always
+    environment:
+      SYSLOG_IDENTIFIER: authd-msentraid
 
 slots:
   dbus-authd:


### PR DESCRIPTION
The default syslog identifier set by snapd includes both the snap name and the service name. Both are the same for this snap, so it doesn't add any value and just clutters the logs.