### PR TITLE
Fail earlier if user is not allowed to log in

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -984,11 +984,11 @@ func TestIsAuthenticatedAllowedUsersConfig(t *testing.T) {
 				require.True(t, json.Valid([]byte(data)), "IsAuthenticated returned data must be a valid JSON")
 				require.NoError(t, err)
 				if slices.Contains(tc.wantAllowedUsers, u) {
-					require.Equal(t, access, broker.AuthGranted, "authentication failed")
+					require.Equal(t, broker.AuthGranted, access, "authentication failed")
 					continue
 				}
 				if slices.Contains(tc.wantUnallowedUsers, u) {
-					require.Equal(t, access, broker.AuthDenied, "authentication failed")
+					require.Equal(t, broker.AuthDenied, access, "authentication failed")
 					continue
 				}
 				t.Fatalf("user %s is not in the allowed or unallowed users list", u)


### PR DESCRIPTION
~~**This is based on https://github.com/ubuntu/authd-oidc-brokers/pull/334, please review and merge that one first**~~

We want the user to perform the OIDC authentication for auditing and logging purposes, but we don't need them to choose a local password before we tell them that they are not allowed to log in.

UDENG-5868