### PR TITLE
Fix post-refresh hook failing if broker.conf.d is empty

### DIFF
--- a/snap/hooks/post-refresh
+++ b/snap/hooks/post-refresh
@@ -68,6 +68,9 @@ transition_to_allowed_users() {
   # directory is created by snapd with the correct permissions.
   mkdir -p --mode=0700 "${dest_dir}"
   for f in "${src_dir}"/*; do
+    if [ ! -f "${f}" ]; then
+      continue
+    fi
     cp --update=none "${f}" "${dest_dir}"
     chmod 0600 "${dest_dir}/$(basename "${f}")"
   done


### PR DESCRIPTION
In that case it failed with:

```
cp: cannot stat '/snap/authd-msentraid/x1/conf/migrations/pre-0.2.0-pre1/broker.conf.d/*': No such file or directory
```