### PR TITLE
Minor broker refactoring and cleanup

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -64,10 +64,9 @@ type session struct {
 	lang     string
 	mode     string
 
-	selectedMode      string
-	firstSelectedMode string
-	authModes         []string
-	attemptsPerMode   map[string]int
+	selectedMode    string
+	authModes       []string
+	attemptsPerMode map[string]int
 
 	oidcServer            *oidc.Provider
 	oauth2Config          oauth2.Config
@@ -322,10 +321,6 @@ func (b *Broker) SelectAuthenticationMode(sessionID, authModeID string) (uiLayou
 
 	// Store selected mode
 	session.selectedMode = authModeID
-	// Store the first one to use to update the lastSelectedMode in MFA cases.
-	if session.currentAuthStep == 0 {
-		session.firstSelectedMode = authModeID
-	}
 
 	if err = b.updateSession(sessionID, session); err != nil {
 		return nil, err

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -218,9 +218,6 @@ func (b *Broker) GetAuthenticationModes(sessionID string, supportedUILayouts []m
 
 	supportedAuthModes := b.supportedAuthModesFromLayout(supportedUILayouts)
 
-	log.Debugf(context.Background(), "Supported UI Layouts for session %s: %#v", sessionID, supportedUILayouts)
-	log.Debugf(context.Background(), "Supported Authentication modes for session %s: %#v", sessionID, supportedAuthModes)
-
 	// Checks if the token exists in the cache.
 	tokenExists, err := fileutils.FileExists(session.tokenPath)
 	if err != nil {

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -17,7 +17,6 @@ import (
 	msgraphauth "github.com/microsoftgraph/msgraph-sdk-go-core/authentication"
 	msgraphmodels "github.com/microsoftgraph/msgraph-sdk-go/models"
 	"github.com/ubuntu/authd-oidc-brokers/internal/broker/authmodes"
-	"github.com/ubuntu/authd-oidc-brokers/internal/broker/sessionmode"
 	"github.com/ubuntu/authd-oidc-brokers/internal/consts"
 	providerErrors "github.com/ubuntu/authd-oidc-brokers/internal/providers/errors"
 	"github.com/ubuntu/authd-oidc-brokers/internal/providers/info"
@@ -280,59 +279,17 @@ func isSecurityGroup(group msgraphmodels.Groupable) bool {
 	return !slices.Contains(group.GetGroupTypes(), "Unified")
 }
 
-// CurrentAuthenticationModesOffered returns the generic authentication modes supported by the provider.
-//
-// Token validity is not considered, only the presence of a token.
-func (p Provider) CurrentAuthenticationModesOffered(
-	sessionMode string,
-	supportedAuthModes map[string]string,
-	tokenExists bool,
-	providerReachable bool,
-	endpoints map[string]struct{},
-	currentAuthStep int,
-) ([]string, error) {
-	log.Debugf(context.Background(), "In CurrentAuthenticationModesOffered: sessionMode=%q, supportedAuthModes=%q, tokenExists=%t, providerReachable=%t, endpoints=%q, currentAuthStep=%d\n", sessionMode, supportedAuthModes, tokenExists, providerReachable, endpoints, currentAuthStep)
-	var offeredModes []string
-	switch sessionMode {
-	case sessionmode.ChangePassword, sessionmode.ChangePasswordOld:
-		if !tokenExists {
-			return nil, errors.New("user has no cached token")
-		}
-		offeredModes = []string{authmodes.Password}
-		if currentAuthStep > 0 {
-			offeredModes = []string{authmodes.NewPassword}
-		}
-
-	default: // auth mode
-		if _, ok := endpoints[authmodes.DeviceQr]; ok && providerReachable {
-			offeredModes = []string{authmodes.DeviceQr}
-		} else if _, ok := endpoints[authmodes.Device]; ok && providerReachable {
-			offeredModes = []string{authmodes.Device}
-		}
-		if tokenExists {
-			offeredModes = append([]string{authmodes.Password}, offeredModes...)
-		}
-		if currentAuthStep > 0 {
-			offeredModes = []string{authmodes.NewPassword}
-		}
-	}
-	log.Debugf(context.Background(), "Offered modes: %q", offeredModes)
-
-	for _, mode := range offeredModes {
-		if _, ok := supportedAuthModes[mode]; !ok {
-			return nil, fmt.Errorf("auth mode %q required by the provider, but is not supported locally", mode)
-		}
-	}
-
-	return offeredModes, nil
-}
-
 // NormalizeUsername parses a username into a normalized version.
 func (p Provider) NormalizeUsername(username string) string {
 	// Microsoft Entra usernames are case-insensitive. We can safely use strings.ToLower here without worrying about
 	// different Unicode characters that fold to the same lowercase letter, because the Microsoft Entra username policy
 	// (which we check in VerifyUsername) ensures that the username only contains ASCII characters.
 	return strings.ToLower(username)
+}
+
+// SupportedOIDCAuthModes returns the OIDC authentication modes supported by the provider.
+func (p Provider) SupportedOIDCAuthModes() []string {
+	return []string{authmodes.Device, authmodes.DeviceQr}
 }
 
 // VerifyUsername checks if the authenticated username matches the requested username and that both are valid.

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -14,17 +14,10 @@ type Provider interface {
 	AdditionalScopes() []string
 	AuthOptions() []oauth2.AuthCodeOption
 	CheckTokenScopes(token *oauth2.Token) error
-	CurrentAuthenticationModesOffered(
-		sessionMode string,
-		supportedAuthModes map[string]string,
-		tokenExists bool,
-		providerReachable bool,
-		endpoints map[string]struct{},
-		currentAuthStep int,
-	) ([]string, error)
 	GetExtraFields(token *oauth2.Token) map[string]interface{}
 	GetMetadata(provider *oidc.Provider) (map[string]interface{}, error)
 	GetUserInfo(ctx context.Context, accessToken *oauth2.Token, idToken *oidc.IDToken, providerMetadata map[string]interface{}) (info.User, error)
 	NormalizeUsername(username string) string
+	SupportedOIDCAuthModes() []string
 	VerifyUsername(requestedUsername, authenticatedUsername string) error
 }


### PR DESCRIPTION
Remove an unused field and move a function that's not provider-specific from the provider interface to the broker. See commit messages for details.