### PR TITLE
Support changing the password if refreshing token or user info fails

### DIFF
--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -455,6 +455,12 @@ func TestIsAuthenticated(t *testing.T) {
 			token:                    &tokenOptions{},
 			useOldNameForSecretField: true,
 		},
+		"Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails": {
+			sessionMode:      sessionmode.ChangePassword,
+			firstMode:        authmodes.Password,
+			token:            &tokenOptions{noUserInfo: true},
+			getUserInfoFails: true,
+		},
 
 		"Error_when_authentication_data_is_invalid":         {invalidAuthData: true},
 		"Error_when_secret_can_not_be_decrypted":            {firstMode: authmodes.Password, badFirstKey: true},

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails/data/provider_url/test-user@email.com/password
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails/data/provider_url/test-user@email.com/token.json
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails/first_call
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails/first_call
@@ -1,0 +1,3 @@
+access: next
+data: '{}'
+err: <nil>


### PR DESCRIPTION
We don't need to refresh the token and user info if the session is for changing the password.