### PR TITLE
Fix snap releases still having version 0.2.0-pre1 instead of 0.2.0

### DIFF
--- a/snap/get_version
+++ b/snap/get_version
@@ -60,14 +60,14 @@ strip_branch_tag_prefix() {
 current_branch=$(git -C "${SNAPCRAFT_PART_SRC}" branch --show-current)
 
 # Get the highest version tag which is prefixed with the current branch name.
-tag=$(git tag --sort=-v:refname --merged="${current_branch}" | grep "^${current_branch}-" | head -1)
+tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="${current_branch}" | grep "^${current_branch}-" | head -1)
 
 # If there is no tag prefixed with the current branch name, use the most
 # recent tag that does not have a non-numerical prefix (that's the case
 # when we're building a snap for testing on a branch that's not
 # "msentraid" or "google").
 if [ -z "${tag}" ]; then
-    tag=$(git tag --sort=-v:refname --merged="${current_branch}" | grep -E '^[0-9]+' | head -1)
+    tag=$(git -c "versionsort.suffix=-pre" tag --sort=-v:refname --merged="${current_branch}" | grep -E '^[0-9]+' | head -1)
 fi
 
 version="${tag}"


### PR DESCRIPTION
`git tag --sort=-v:refname` sorts tagnames with the same base version but different suffixes in lexicographical order, causing prerelease tags to be listed as higher than the main release. This results in the snaps still having `0.2.0-pre1+...` versions instead of `0.2.0+...`.

Git supports the `versionsort.suffix` option to avoid exactly that, so let's use it.