### PR TITLE
Bump Go toolchain version to 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ubuntu/authd-oidc-brokers
 
 go 1.23.0
 
+toolchain go1.23.5
+
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.17.0
 	github.com/coreos/go-oidc/v3 v3.12.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,6 +2,8 @@ module github.com/ubuntu/authd-oidc-brokers/tools
 
 go 1.23.0
 
+toolchain go1.23.5
+
 require github.com/golangci/golangci-lint v1.63.4
 
 require (


### PR DESCRIPTION
govulncheck reports multiple vulnerabilities affecting Go versions before 1.23.5:

```
Vulnerability #1: GO-2025-3420
    Sensitive headers incorrectly sent after cross-domain redirect in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3420
  Standard library
    Found in: net/http@go1.23
    Fixed in: net/http@go1.23.5

Vulnerability #2: GO-2025-3373
    Usage of IPv6 zone IDs can bypass URI name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-3373
  Standard library
    Found in: crypto/x509@go1.23
    Fixed in: crypto/x509@go1.23.5
```