### PR TITLE
Log authentication failures caused by an incorrect local password

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -574,6 +574,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 				return AuthDenied, errorMessage{Message: "could not check password"}
 			}
 			if !ok {
+				log.Warningf(context.Background(), "Authentication failure: incorrect local password for user %q", session.username)
 				return AuthRetry, errorMessage{Message: "incorrect password"}
 			}
 


### PR DESCRIPTION
Unsuccessful authentication attempts are security relevant, so we should make sure to log all cases of those. See also
https://owasp.org/Top10/A09_2021-Security_Logging_and_Monitoring_Failures/