### PR TITLE
cmd/authd-oidc/daemon: Warn on no config file

### DIFF
--- a/cmd/authd-oidc/daemon/config.go
+++ b/cmd/authd-oidc/daemon/config.go
@@ -49,7 +49,7 @@ func initViperConfig(name string, cmd *cobra.Command, vip *viper.Viper) (err err
 	if err := vip.ReadInConfig(); err != nil {
 		var e viper.ConfigFileNotFoundError
 		if errors.As(err, &e) {
-			log.Infof(context.Background(), "No configuration file: %v.\nWe will only use the defaults, env variables or flags.", e)
+			log.Warningf(context.Background(), "No configuration file: %v.\nWe will only use the defaults, env variables or flags.", e)
 		} else {
 			return fmt.Errorf("invalid configuration file: %w", err)
 		}


### PR DESCRIPTION
Warn for "Non-critical entries that deserve eyes." A missing config file can cause the broker to fail to connect to the provider.

Default level is `2`, `Infof` is log level `0` and `Warningf` is `4`.