### PR TITLE
internal/broker: Warn when switching to offline mode

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -183,7 +183,7 @@ func (b *Broker) NewSession(username, lang, mode string) (sessionID, encryptionK
 	// Construct an OIDC provider via OIDC discovery.
 	s.oidcServer, err = b.connectToOIDCServer(context.Background())
 	if err != nil {
-		log.Debugf(context.Background(), "Could not connect to the provider: %v. Starting session in offline mode.", err)
+		log.Noticef(context.Background(), "Could not connect to the provider: %v. Starting session in offline mode.", err)
 		s.isOffline = true
 	}
 


### PR DESCRIPTION
If a user gives an invalid issuer URL in broker.conf, go-oidc will return an error with the HTTP response code:
```
Could not connect to the provider: 404 Not Found: . Starting session in offline mode.
```

We shouldn't leave users guessing as to the online/offline state of the broker, especially not the reason for that state choice.

I would have used `Noticef` here instead of `Warningf` but authd 0.4.1 doesn't have `Noticef`.