### PR TITLE
Parse coverage to Cobertura format and upload them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,14 @@ jobs:
           sudo apt update
           sudo apt install -y git-delta
 
+      - name: Install coverage collection dependencies
+        run: |
+          set -eu
+
+          go install github.com/AlekSi/gocov-xml@latest
+          go install github.com/axw/gocov/gocov@latest
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+
       - name: Prepare tests artifacts path
         run: |
           set -eu
@@ -49,9 +57,11 @@ jobs:
           set -eu
 
           # The coverage is not written if the output directory does not exist, so we need to create it.
-          raw_cov_dir="/tmp/raw_files"
-          rm -fr "${raw_cov_dir}"
-          mkdir -p "${raw_cov_dir}"
+          cov_dir=${PWD}/coverage
+          raw_cov_dir=${cov_dir}/raw_files
+          codecov_dir=${cov_dir}/codecov
+
+          mkdir -p "${raw_cov_dir}" "${codecov_dir}"
 
           # Print executed commands to ease debugging
           set -x
@@ -63,10 +73,31 @@ jobs:
             gotestfmt --logfile "${AUTHD_TEST_ARTIFACTS_DIR}/gotestfmt.cover.log"
 
           # Convert the raw coverage data into textfmt so we can merge the Rust one into it
-          go tool covdata textfmt -i="${raw_cov_dir}" -o="/tmp/coverage.out"
+          go tool covdata textfmt -i="${raw_cov_dir}" -o="${cov_dir}/coverage.out"
 
-          # Filter out the testutils package and the pb.go file
-          grep -v -e "testutils" "/tmp/coverage.out" >"/tmp/coverage.out.filtered"
+          # Filter out the testutils package
+          grep -v -e "testutils" "${cov_dir}/coverage.out" >"${cov_dir}/coverage.out.filtered"
+
+          # Generate the Cobertura report for Go
+          gocov convert "${cov_dir}/coverage.out.filtered" | gocov-xml > "${cov_dir}/coverage.xml"
+          reportgenerator -reports:"${cov_dir}/coverage.xml" -targetdir:"${codecov_dir}" -reporttypes:Cobertura
+
+          # Store the coverage directory for the next steps
+          echo COVERAGE_DIR="${codecov_dir}" >> ${GITHUB_ENV}
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ${{ env.COVERAGE_DIR }}
+          files: ${{ env.COVERAGE_DIR }}/Cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload coverage report as artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage.zip
+          path: ${{ env.COVERAGE_DIR }}
 
       - name: Upload test artifacts
         if: failure()


### PR DESCRIPTION
So far, the repo was not hooked into Codecov so we had no test coverage reports automatically available. Let's finally handle this whilst also setting up the needed Cobertura format required by TiCS.

UDENG-5877