### PR TITLE
Fix invalid golangci-lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -57,5 +57,7 @@ linters-settings:
   nakedret:
     max-func-lines: 1
   nolintlint:
+    # Require an explanation of nonzero length after each nolint directive.
     require-explanation: true
+    # Require nolint directives to mention the specific linter being suppressed.
     require-specific: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,10 +47,6 @@ issues:
     # Sometimes it is more readable it do a `if err:=a(); err != nil` tha simpy `return a()`
     - if-return
 
-nolintlint:
-  require-explanation: true
-  require-specific: true
-
 linters-settings:
   # Forbid the usage of deprecated ioutil and debug prints
   forbidigo:
@@ -60,3 +56,6 @@ linters-settings:
   # Never have naked return ever
   nakedret:
     max-func-lines: 1
+  nolintlint:
+    require-explanation: true
+    require-specific: true


### PR DESCRIPTION
The nolintlint settings must be part of the "linters-settings" list.

Fixes that golangci-lint fails in the CI with:

    Failed to run: Error: Command failed: /home/runner/golangci-lint-1.63.4-linux-amd64/golangci-lint config verify
    jsonschema: "" does not validate with "/additionalProperties": additional properties 'nolintlint' not allowed
    Failed executing command with error: the configuration contains invalid elements
