### PR TITLE
Fix device auth being the default when local password is available

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -261,15 +261,18 @@ func (b *Broker) availableAuthModes(session session) (availableModes []string, e
 
 	switch session.mode {
 	case sessionmode.ChangePassword, sessionmode.ChangePasswordOld:
-		// session is for changing the password
+		// Session is for changing the password.
 		if !tokenExists(session) {
 			return nil, errors.New("user has no cached token")
 		}
 		return []string{authmodes.Password}, nil
 
 	default:
-		// session is for login
-		modes := append(b.provider.SupportedOIDCAuthModes(), authmodes.Password)
+		// Session is for login. Check which auth modes are available.
+		// The order of the modes is important, because authd picks the first supported one.
+		// Password authentication should be the first option if available, to avoid performing device authentication
+		// when it's not necessary.
+		modes := append([]string{authmodes.Password}, b.provider.SupportedOIDCAuthModes()...)
 		for _, mode := range modes {
 			if authModeIsAvailable(session, mode) {
 				availableModes = append(availableModes, mode)

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -230,7 +230,7 @@ func (b *Broker) GetAuthenticationModes(sessionID string, supportedUILayouts []m
 
 	for _, mode := range availableModes {
 		if !slices.Contains(modesSupportedByUI, mode) {
-			log.Infof(context.Background(), "Authentication mode %q is not supported by the UI", mode)
+			log.Debugf(context.Background(), "Authentication mode %q is not supported by the UI", mode)
 			continue
 		}
 

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -170,21 +170,22 @@ func TestGetAuthenticationModes(t *testing.T) {
 		unavailableProvider   bool
 		deviceAuthUnsupported bool
 
-		wantErr bool
+		wantErr       bool
+		wantFirstMode string
 	}{
 		// Authentication session
-		"Get_device_auth_qr_if_there_is_no_token":           {},
-		"Get_password_and_device_auth_qr_if_token_exists":   {tokenExists: true},
-		"Get_newpassword_if_next_auth_mode_is_newpassword":  {nextAuthMode: authmodes.NewPassword},
-		"Get_device_auth_qr_if_next_auth_mode_is_device_qr": {nextAuthMode: authmodes.DeviceQr},
+		"Get_device_auth_qr_if_there_is_no_token":           {wantFirstMode: authmodes.DeviceQr},
+		"Get_password_and_device_auth_qr_if_token_exists":   {tokenExists: true, wantFirstMode: authmodes.Password},
+		"Get_newpassword_if_next_auth_mode_is_newpassword":  {nextAuthMode: authmodes.NewPassword, wantFirstMode: authmodes.NewPassword},
+		"Get_device_auth_qr_if_next_auth_mode_is_device_qr": {nextAuthMode: authmodes.DeviceQr, wantFirstMode: authmodes.DeviceQr},
 
-		"Get_only_password_if_token_exists_and_provider_is_not_available":                {tokenExists: true, providerAddress: "127.0.0.1:31310", unavailableProvider: true},
-		"Get_only_password_if_token_exists_and_provider_does_not_support_device_auth_qr": {tokenExists: true, providerAddress: "127.0.0.1:31311", deviceAuthUnsupported: true},
+		"Get_only_password_if_token_exists_and_provider_is_not_available":                {tokenExists: true, providerAddress: "127.0.0.1:31310", unavailableProvider: true, wantFirstMode: authmodes.Password},
+		"Get_only_password_if_token_exists_and_provider_does_not_support_device_auth_qr": {tokenExists: true, providerAddress: "127.0.0.1:31311", deviceAuthUnsupported: true, wantFirstMode: authmodes.Password},
 
 		// Change password session
-		"Get_only_password_if_token_exists_and_session_is_for_changing_password":                {sessionMode: sessionmode.ChangePassword, tokenExists: true},
-		"Get_newpassword_if_session_is_for changing_password_and_next_auth_mode_is_newpassword": {sessionMode: sessionmode.ChangePassword, tokenExists: true, nextAuthMode: authmodes.NewPassword},
-		"Get_only_password_if_token_exists_and_session_mode_is_the_old_passwd_value":            {sessionMode: sessionmode.ChangePasswordOld, tokenExists: true},
+		"Get_only_password_if_token_exists_and_session_is_for_changing_password":                {sessionMode: sessionmode.ChangePassword, tokenExists: true, wantFirstMode: authmodes.Password},
+		"Get_newpassword_if_session_is_for changing_password_and_next_auth_mode_is_newpassword": {sessionMode: sessionmode.ChangePassword, tokenExists: true, nextAuthMode: authmodes.NewPassword, wantFirstMode: authmodes.NewPassword},
+		"Get_only_password_if_token_exists_and_session_mode_is_the_old_passwd_value":            {sessionMode: sessionmode.ChangePasswordOld, tokenExists: true, wantFirstMode: authmodes.Password},
 
 		"Error_if_there_is_no_session": {sessionID: "-", wantErr: true},
 
@@ -255,6 +256,10 @@ func TestGetAuthenticationModes(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "GetAuthenticationModes should not have returned an error")
+
+			if tc.wantFirstMode != "" {
+				require.Equal(t, tc.wantFirstMode, got[0]["id"], "First mode should be the expected one")
+			}
 
 			golden.CheckOrUpdateYAML(t, got)
 		})

--- a/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_token_exists
+++ b/internal/broker/testdata/golden/TestGetAuthenticationModes/Get_password_and_device_auth_qr_if_token_exists
@@ -1,4 +1,4 @@
-- id: device_auth_qr
-  label: Device Authentication
 - id: password
   label: Local Password Authentication
+- id: device_auth_qr
+  label: Device Authentication


### PR DESCRIPTION
Commit 8ded61bf39b64dabd7f9543aee9e47874177c60e changed the order of the
available modes, putting password authentication last.

The order is actually important, because authd picks the first one.

This PR fixes the order and adds a comment explaining why the order
is important.

Closes https://github.com/ubuntu/authd/issues/812
UDENG-6176