### PR TITLE
Bump Go version to 1.24.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/authd-oidc-brokers
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ubuntu/authd-oidc-brokers/tools
 
-go 1.23.0
+go 1.24.0
 
 toolchain go1.24.1
 


### PR DESCRIPTION
Some dependencies ([go-oidc](https://github.com/ubuntu/authd-oidc-brokers/pull/440), [viper](https://github.com/ubuntu/authd-oidc-brokers/pull/442)) require Go version 1.24.0 now.