### PR TITLE
Add tags to ignore static check on helper files

### DIFF
--- a/internal/consts/generate.go
+++ b/internal/consts/generate.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a helper file to generate the consts used based on which broker was built.
+
 //go:build generate
 
 package main

--- a/internal/dbusservice/localbus.go
+++ b/internal/dbusservice/localbus.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a helper file for tests.
+
 //go:build withlocalbus
 
 package dbusservice

--- a/po/mofiles.go
+++ b/po/mofiles.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a helper file.
+
 //go:build withmo && !windows
 
 package po

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,3 +1,5 @@
+// TiCS: disabled // This is a helper file to pin the tools versions that we use.
+
 //go:build tools
 
 package tools


### PR DESCRIPTION
We have a lot of helper files to help us test our project and those are protected to not be built with "go build" to avoid having those in the release binary. To avoid having to update tics configuration every time we rename those files or add new ones, let's tag them and filter those out in the analysis.