### PR TITLE
Add option to force token refresh on login

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -6,6 +6,18 @@ client_id = <CLIENT_ID>
 ## client secret to authenticate with the provider.
 #client_secret = <CLIENT_SECRET>
 
+## Always authenticate with the identity provider during login, even if
+## a local method (e.g. local password) is used.
+## This works by forcing a token refresh at login, which fails if the
+## user does not have the necessary permissions in the identity provider.
+##
+## If set to false (the default), authentication with the identity
+## provider is only done if the provider is reachable during login.
+##
+## Important: Enabling this option prevents authd users from logging in
+## if the identity provider is unreachable (e.g. due to network issues).
+#force_provider_authentication = false
+
 [users]
 ## The directory where the home directories of new users are created.
 ## Existing users will keep their current home directory.

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -626,8 +626,12 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 			return AuthNext, nil
 		}
 
+		if b.cfg.forceProviderAuthentication && session.isOffline {
+			return AuthDenied, errorMessage{Message: "could not refresh token: provider is not reachable"}
+		}
+
 		// Refresh the token if we're online even if the token has not expired
-		if !session.isOffline {
+		if b.cfg.forceProviderAuthentication || !session.isOffline {
 			authInfo, err = b.refreshToken(ctx, session.oauth2Config, authInfo)
 			var retrieveErr *oauth2.RetrieveError
 			if errors.As(err, &retrieveErr) && b.provider.IsTokenExpiredError(*retrieveErr) {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -95,8 +95,6 @@ type Option func(*option)
 
 // New returns a new oidc Broker with the providers listed in the configuration file.
 func New(cfg Config, args ...Option) (b *Broker, err error) {
-	defer decorate.OnError(&err, "could not create broker")
-
 	p := providers.CurrentProvider()
 
 	if cfg.ConfigFile != "" {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -102,7 +102,7 @@ func New(cfg Config, args ...Option) (b *Broker, err error) {
 	if cfg.ConfigFile != "" {
 		cfg.userConfig, err = parseConfigFile(cfg.ConfigFile, p)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse config: %v", err)
+			return nil, fmt.Errorf("could not parse config file '%s': %v", cfg.ConfigFile, err)
 		}
 	}
 

--- a/internal/broker/config.go
+++ b/internal/broker/config.go
@@ -16,6 +16,9 @@ import (
 
 // Configuration sections and keys.
 const (
+	// forceProviderAuthenticationKey is the key in the config file for the option to force provider authentication during login.
+	forceProviderAuthenticationKey = "force_provider_authentication"
+
 	// oidcSection is the section name in the config file for the OIDC specific configuration.
 	oidcSection = "oidc"
 	// issuerKey is the key in the config file for the issuer.
@@ -63,6 +66,8 @@ type userConfig struct {
 	clientID     string
 	clientSecret string
 	issuerURL    string
+
+	forceProviderAuthentication bool
 
 	allowedUsers          map[string]struct{}
 	allUsersAllowed       bool
@@ -180,6 +185,12 @@ func parseConfigFile(cfgPath string, p provider) (userConfig, error) {
 		cfg.issuerURL = oidc.Key(issuerKey).String()
 		cfg.clientID = oidc.Key(clientIDKey).String()
 		cfg.clientSecret = oidc.Key(clientSecret).String()
+		if oidc.HasKey(forceProviderAuthenticationKey) {
+			cfg.forceProviderAuthentication, err = oidc.Key(forceProviderAuthenticationKey).Bool()
+			if err != nil {
+				return cfg, fmt.Errorf("error parsing '%s': %w", forceProviderAuthenticationKey, err)
+			}
+		}
 	}
 
 	cfg.populateUsersConfig(iniCfg.Section(usersSection))

--- a/internal/broker/config_test.go
+++ b/internal/broker/config_test.go
@@ -26,10 +26,18 @@ client_id = client_id
 [oidc]
 issuer = https://issuer.url.com
 client_id = client_id
+force_provider_authentication = true
 
 [users]
 home_base_dir = /home
 allowed_ssh_suffixes = @issuer.url.com
+`,
+
+	"invalid_boolean_value": `
+[oidc]
+issuer = https://issuer.url.com
+client_id = client_id
+force_provider_authentication = invalid
 `,
 
 	"singles": `
@@ -78,6 +86,7 @@ func TestParseConfig(t *testing.T) {
 		"Error_if_file_is_not_updated":             {configType: "template", wantErr: true},
 		"Error_if_drop_in_directory_is_unreadable": {dropInType: "unreadable-dir", wantErr: true},
 		"Error_if_drop_in_file_is_unreadable":      {dropInType: "unreadable-file", wantErr: true},
+		"Error_if_config_contains_invalid_values":  {configType: "invalid_boolean_value", wantErr: true},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/broker/export_test.go
+++ b/internal/broker/export_test.go
@@ -20,6 +20,10 @@ func (cfg *Config) SetIssuerURL(issuerURL string) {
 	cfg.issuerURL = issuerURL
 }
 
+func (cfg *Config) SetForceProviderAuthentication(value bool) {
+	cfg.forceProviderAuthentication = value
+}
+
 func (cfg *Config) SetHomeBaseDir(homeBaseDir string) {
 	cfg.homeBaseDir = homeBaseDir
 }

--- a/internal/broker/helper_test.go
+++ b/internal/broker/helper_test.go
@@ -24,15 +24,16 @@ import (
 
 type brokerForTestConfig struct {
 	broker.Config
-	issuerURL             string
-	allowedUsers          map[string]struct{}
-	allUsersAllowed       bool
-	ownerAllowed          bool
-	firstUserBecomesOwner bool
-	owner                 string
-	homeBaseDir           string
-	allowedSSHSuffixes    []string
-	provider              providers.Provider
+	issuerURL                   string
+	forceProviderAuthentication bool
+	allowedUsers                map[string]struct{}
+	allUsersAllowed             bool
+	ownerAllowed                bool
+	firstUserBecomesOwner       bool
+	owner                       string
+	homeBaseDir                 string
+	allowedSSHSuffixes          []string
+	provider                    providers.Provider
 
 	getUserInfoFails bool
 	firstCallDelay   int
@@ -51,6 +52,9 @@ func newBrokerForTests(t *testing.T, cfg *brokerForTestConfig) (b *broker.Broker
 	cfg.Init()
 	if cfg.issuerURL != "" {
 		cfg.SetIssuerURL(cfg.issuerURL)
+	}
+	if cfg.forceProviderAuthentication {
+		cfg.SetForceProviderAuthentication(cfg.forceProviderAuthentication)
 	}
 	if cfg.homeBaseDir != "" {
 		cfg.SetHomeBaseDir(cfg.homeBaseDir)

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_authentication_is_forced/data/provider_url/test-user@email.com/password
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_authentication_is_forced/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_authentication_is_forced/data/provider_url/test-user@email.com/token.json
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_authentication_is_forced/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_authentication_is_forced/first_call
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_provider_authentication_is_forced/first_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/test-user@email.com","shell":"/usr/bin/bash","gecos":"test-user@email.com","groups":[{"name":"remote-test-group","ugid":"12345"},{"name":"local-test-group","ugid":""}]}}'
+err: <nil>

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_provider_authentication_is_forced_and_session_is_offline/data/provider_url/test-user@email.com/password
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_provider_authentication_is_forced_and_session_is_offline/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_provider_authentication_is_forced_and_session_is_offline/data/provider_url/test-user@email.com/token.json
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_provider_authentication_is_forced_and_session_is_offline/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_provider_authentication_is_forced_and_session_is_offline/first_call
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Error_when_provider_authentication_is_forced_and_session_is_offline/first_call
@@ -1,0 +1,3 @@
+access: denied
+data: '{"message":"authentication failure: could not refresh token: provider is not reachable"}'
+err: <nil>

--- a/internal/broker/testdata/golden/TestParseConfig/Do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
+++ b/internal/broker/testdata/golden/TestParseConfig/Do_not_fail_if_values_contain_a_single_template_delimiter/config.txt
@@ -1,6 +1,7 @@
 clientID=<CLIENT_ID
 clientSecret=
 issuerURL=https://ISSUER_URL>
+forceProviderAuthentication=false
 allowedUsers=map[]
 allUsersAllowed=false
 ownerAllowed=true

--- a/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file/config.txt
+++ b/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file/config.txt
@@ -1,6 +1,7 @@
 clientID=client_id
 clientSecret=
 issuerURL=https://issuer.url.com
+forceProviderAuthentication=false
 allowedUsers=map[]
 allUsersAllowed=false
 ownerAllowed=true

--- a/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file_with_optional_values/config.txt
+++ b/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_file_with_optional_values/config.txt
@@ -1,6 +1,7 @@
 clientID=client_id
 clientSecret=
 issuerURL=https://issuer.url.com
+forceProviderAuthentication=true
 allowedUsers=map[]
 allUsersAllowed=false
 ownerAllowed=true

--- a/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_with_drop_in_files/config.txt
+++ b/internal/broker/testdata/golden/TestParseConfig/Successfully_parse_config_with_drop_in_files/config.txt
@@ -1,6 +1,7 @@
 clientID=lower_precedence_client_id
 clientSecret=
 issuerURL=https://higher-precedence-issuer.url.com
+forceProviderAuthentication=true
 allowedUsers=map[]
 allUsersAllowed=false
 ownerAllowed=true


### PR DESCRIPTION
This option forces refreshing the token on login, so that user accounts which were disabled or removed from the identity provider can't log in anymore.

Closes #813
UDENG-6177

# TODO
* [x] Add a test case to `internal/broker/config_test.go`
  * The implementation depends on which config section we add the new option to, so let's decide that first.