### PR TITLE
Fix invalid msgraph host

### DIFF
--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -115,6 +115,12 @@ func (p Provider) GetUserInfo(ctx context.Context, accessToken *oauth2.Token, id
 		if !ok {
 			return info.User{}, fmt.Errorf("failed to cast msgraph_host to string: %v", providerMetadata["msgraph_host"])
 		}
+
+		// Handle the case that the provider metadata only contains the host without the protocol and API version,
+		// as was the case before 5fc98520c45294ffb85bb27a81929e2ec1b89fcb. This fixes #858.
+		if !strings.Contains(msgraphHost, "://") {
+			msgraphHost = fmt.Sprintf("https://%s/%s", msgraphHost, msgraphAPIVersion)
+		}
 	}
 
 	userClaims, err := p.userClaims(idToken)


### PR DESCRIPTION
Since commit 5fc98520c45294ffb85bb27a81929e2ec1b89fcb, we store the full
URL to the msgraph host in the provider metadata. However, the metadata
on disk is not updated, so it can still contain only the domain name of
the msgraph host, resulting in a failure to get the groups via msgraph:

    Could not fetch user info: could not get user info: failed to get user groups: failed to get user groups: Get "graph.microsoft.com/me/transitiveMemberOf/graph.group": unsupported protocol scheme "". Using cached user info.

This PR fixes that by supporting both the old and new formats of the
msgraph host field in the provider metadata.

Closes https://github.com/ubuntu/authd/issues/858
UDENG-6537
