### PR TITLE
Bump Go toolchain version to 1.24.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers
 
 go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0


### PR DESCRIPTION
govulncheck reports the following vulnerability in go1.24.1

```
Vulnerability #1: GO-2025-3563
    Request smuggling due to acceptance of invalid chunked data in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-3563
  Standard library
    Found in: net/http/internal@go1.24.1
    Fixed in: net/http/internal@go1.24.2
```