### PR TITLE
 Don't overwrite shell when refreshing user info

### DIFF
--- a/internal/broker/helper_test.go
+++ b/internal/broker/helper_test.go
@@ -179,6 +179,8 @@ func generateAndStoreCachedInfo(t *testing.T, options tokenOptions, path string)
 type tokenOptions struct {
 	username string
 	issuer   string
+	home     string
+	shell    string
 	groups   []info.Group
 
 	expired             bool
@@ -246,6 +248,12 @@ func generateCachedInfo(t *testing.T, options tokenOptions) *token.AuthCachedInf
 				{Name: "saved-remote-group", UGID: "12345"},
 				{Name: "saved-local-group", UGID: ""},
 			},
+		}
+		if options.home != "" {
+			tok.UserInfo.Home = options.home
+		}
+		if options.shell != "" {
+			tok.UserInfo.Shell = options.shell
 		}
 		if options.groups != nil {
 			tok.UserInfo.Groups = options.groups

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Home_and_shell_are_not_overwritten_when_user_info_is_refreshed/data/provider_url/test-user@email.com/password
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Home_and_shell_are_not_overwritten_when_user_info_is_refreshed/data/provider_url/test-user@email.com/password
@@ -1,0 +1,1 @@
+Definitely a hashed password

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Home_and_shell_are_not_overwritten_when_user_info_is_refreshed/data/provider_url/test-user@email.com/token.json
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Home_and_shell_are_not_overwritten_when_user_info_is_refreshed/data/provider_url/test-user@email.com/token.json
@@ -1,0 +1,1 @@
+Definitely an encrypted token

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Home_and_shell_are_not_overwritten_when_user_info_is_refreshed/first_call
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Home_and_shell_are_not_overwritten_when_user_info_is_refreshed/first_call
@@ -1,0 +1,3 @@
+access: granted
+data: '{"userinfo":{"name":"test-user@email.com","uuid":"test-user-id","dir":"/home/old-home","shell":"/bin/old-shell","gecos":"test-user@email.com","groups":[{"name":"remote-test-group","ugid":"12345"},{"name":"local-test-group","ugid":""}]}}'
+err: <nil>


### PR DESCRIPTION
The user's shell should be configurable locally and not overwritten when the user info is being refreshed.

Closes https://github.com/ubuntu/authd/issues/880