### PR TITLE
Improve error message shown when user is not allowed

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -570,7 +570,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 		}
 
 		if !b.userNameIsAllowed(authInfo.UserInfo.Name) {
-			log.Warningf(context.Background(), "User %q is not in the list of allowed users", authInfo.UserInfo.Name)
+			log.Warning(context.Background(), b.userNotAllowedLogMsg(authInfo.UserInfo.Name))
 			return AuthDenied, errorMessage{Message: "user not allowed in broker configuration"}
 		}
 
@@ -684,7 +684,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 	}
 
 	if !b.userNameIsAllowed(authInfo.UserInfo.Name) {
-		log.Warningf(context.Background(), "User %q is not in the list of allowed users", authInfo.UserInfo.Name)
+		log.Warning(context.Background(), b.userNotAllowedLogMsg(authInfo.UserInfo.Name))
 		return AuthDenied, errorMessage{Message: "user not allowed in broker configuration"}
 	}
 
@@ -707,6 +707,12 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 // userNameIsAllowed checks whether the user's username is allowed to access the machine.
 func (b *Broker) userNameIsAllowed(userName string) bool {
 	return b.cfg.userNameIsAllowed(b.provider.NormalizeUsername(userName))
+}
+
+func (b *Broker) userNotAllowedLogMsg(userName string) string {
+	logMsg := fmt.Sprintf("User %q is not in the list of allowed users.", userName)
+	logMsg += fmt.Sprintf("\nYou can add the user to allowed_users in %s", b.cfg.ConfigFile)
+	return logMsg
 }
 
 func (b *Broker) startAuthenticate(sessionID string) (context.Context, error) {

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -571,7 +571,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 
 		if !b.userNameIsAllowed(authInfo.UserInfo.Name) {
 			log.Warningf(context.Background(), "User %q is not in the list of allowed users", authInfo.UserInfo.Name)
-			return AuthDenied, errorMessage{Message: "permission denied"}
+			return AuthDenied, errorMessage{Message: "user not allowed in broker configuration"}
 		}
 
 		session.authInfo["auth_info"] = authInfo
@@ -685,7 +685,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 
 	if !b.userNameIsAllowed(authInfo.UserInfo.Name) {
 		log.Warningf(context.Background(), "User %q is not in the list of allowed users", authInfo.UserInfo.Name)
-		return AuthDenied, errorMessage{Message: "permission denied"}
+		return AuthDenied, errorMessage{Message: "user not allowed in broker configuration"}
 	}
 
 	if session.isOffline {

--- a/internal/broker/testdata/golden/TestConcurrentIsAuthenticated/First_auth_starts_first_but_second_finishes_first_and_is_registered_as_the_owner/first_auth
+++ b/internal/broker/testdata/golden/TestConcurrentIsAuthenticated/First_auth_starts_first_but_second_finishes_first_and_is_registered_as_the_owner/first_auth
@@ -1,3 +1,3 @@
 access: denied
-data: '{"message":"authentication failure: permission denied"}'
+data: '{"message":"authentication failure: user not allowed in broker configuration"}'
 err: <nil>


### PR DESCRIPTION
Multiple users were confused by the default behavior that only the first user is allowed to log in and all other users get a permission denied.
    
The documentation was improved in https://github.com/ubuntu/authd/pull/888.
    
This PR also improves the error message and log messages that are shown when the user is not allowed, to explain better why the login failed and what can be done about it.

UDENG-6825