### PR TITLE
More helpful error messages

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -536,6 +536,9 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 
 		if response.Expiry.IsZero() {
 			response.Expiry = time.Now().Add(time.Hour)
+			log.Debugf(context.Background(), "Device code does not have an expiry time, using default of %s", response.Expiry)
+		} else {
+			log.Debugf(context.Background(), "Device code expiry time: %s", response.Expiry)
 		}
 		expiryCtx, cancel := context.WithDeadline(ctx, response.Expiry)
 		defer cancel()

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -521,7 +521,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 	// Decrypt secret if present.
 	secret, err := decodeRawSecret(b.privateKey, rawSecret)
 	if err != nil {
-		log.Error(context.Background(), err.Error())
+		log.Errorf(context.Background(), "could not decode secret: %s", err)
 		return AuthRetry, errorMessage{Message: "could not decode secret"}
 	}
 
@@ -541,12 +541,12 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 		defer cancel()
 		t, err := session.oauth2Config.DeviceAccessToken(expiryCtx, response, b.provider.AuthOptions()...)
 		if err != nil {
-			log.Error(context.Background(), err.Error())
+			log.Errorf(context.Background(), "could not authenticate user remotely: %s", err)
 			return AuthRetry, errorMessage{Message: "could not authenticate user remotely"}
 		}
 
 		if err = b.provider.CheckTokenScopes(t); err != nil {
-			log.Warning(context.Background(), err.Error())
+			log.Warningf(context.Background(), "error checking token scopes: %s", err)
 		}
 
 		rawIDToken, ok := t.Extra("id_token").(string)
@@ -559,13 +559,13 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 
 		authInfo.ProviderMetadata, err = b.provider.GetMetadata(session.oidcServer)
 		if err != nil {
-			log.Error(context.Background(), err.Error())
+			log.Errorf(context.Background(), "could not get provider metadata: %s", err)
 			return AuthDenied, errorMessage{Message: "could not get provider metadata"}
 		}
 
 		authInfo.UserInfo, err = b.fetchUserInfo(ctx, session, &authInfo)
 		if err != nil {
-			log.Error(context.Background(), err.Error())
+			log.Errorf(context.Background(), "could not fetch user info: %s", err)
 			return AuthDenied, errorMessageForDisplay(err, "could not fetch user info")
 		}
 


### PR DESCRIPTION
* Print debug log statements with the device code expiry time
    
    We're seeing some context deadline errors when sending requests to the
    token endpoint, which might be due to the device code expiry time from
    the device auth response. Let's add some log statements to help debug
    this.

*    Add context to error message
    
     The error message returned as isAuthenticatedDataResponse is never
    logged. As a result, the errors we log miss context, so it's hard to
    figure out where in the code they originate from. Therefore, we add some
    context to those error messages here.
