### PR TITLE
Store directory extension attributes in token.json

### DIFF
--- a/internal/providers/info/info.go
+++ b/internal/providers/info/info.go
@@ -3,8 +3,9 @@ package info
 
 // Group represents the group information that is fetched by the broker.
 type Group struct {
-	Name string `json:"name"`
-	UGID string `json:"ugid"`
+	Name        string         `json:"name"`
+	UGID        string         `json:"ugid"`
+	ExtraFields map[string]any `json:"extra_fields,omitempty"`
 }
 
 // User represents the user information obtained from the provider.

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -220,6 +220,18 @@ func (p Provider) getGroups(token *oauth2.Token, msgraphHost string) ([]info.Gro
 			continue
 		}
 
+		// Store directory extension attributes, if any.
+		additionalData := msGroup.GetAdditionalData()
+		if additionalData != nil {
+			group.ExtraFields = make(map[string]any)
+			for k, v := range additionalData {
+				// Directory extension attributes start with "extension_"
+				if strings.HasPrefix(k, "extension_") && v != nil {
+					group.ExtraFields[k] = v
+				}
+			}
+		}
+
 		// Microsoft groups are case-insensitive, see https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules
 		group.Name = strings.ToLower(msGroupName)
 


### PR DESCRIPTION
To support the use case that groups are assigned additional data via directory extensions, which should be accessible to admins of the local system, we now store the directory extension attributes of a group in the token.json file in the broker's data directory.

This is on request of a user who wants to have shared user and group IDs on all systems using authd, and wants to achieve that by setting IDs via directory extensions, then read those once the user logged in and use authctl to change the user/group ID to the one from the directory extension (once authctl supports that).

The directory extension attributes of user objects can already be stored in the token.json file, by emitting them as claims in the ID token (which is stored in JWT format in the RawIDToken field of token.json): https://learn.microsoft.com/en-us/entra/identity-platform/schema-extensions

Closes https://github.com/ubuntu/authd/issues/630
UDENG-7195