### PR TITLE
Show more useful error message

### DIFF
--- a/internal/providers/genericprovider/genericprovider.go
+++ b/internal/providers/genericprovider/genericprovider.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/ubuntu/authd-oidc-brokers/internal/broker/authmodes"
+	providerErrors "github.com/ubuntu/authd-oidc-brokers/internal/providers/errors"
 	"github.com/ubuntu/authd-oidc-brokers/internal/providers/info"
 	"golang.org/x/oauth2"
 )
@@ -76,7 +77,7 @@ func (p GenericProvider) NormalizeUsername(username string) string {
 // VerifyUsername checks if the requested username matches the authenticated user.
 func (p GenericProvider) VerifyUsername(requestedUsername, username string) error {
 	if p.NormalizeUsername(requestedUsername) != p.NormalizeUsername(username) {
-		return fmt.Errorf("requested username %q does not match the authenticated user %q", requestedUsername, username)
+		return providerErrors.NewForDisplayError("requested username %q does not match the authenticated user %q", requestedUsername, username)
 	}
 	return nil
 }

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -350,7 +350,7 @@ func (p Provider) SupportedOIDCAuthModes() []string {
 // VerifyUsername checks if the authenticated username matches the requested username and that both are valid.
 func (p Provider) VerifyUsername(requestedUsername, authenticatedUsername string) error {
 	if p.NormalizeUsername(requestedUsername) != p.NormalizeUsername(authenticatedUsername) {
-		return fmt.Errorf("requested username %q does not match the authenticated user %q", requestedUsername, authenticatedUsername)
+		return providerErrors.NewForDisplayError("requested username %q does not match the authenticated user %q", requestedUsername, authenticatedUsername)
 	}
 
 	// Check that the usernames only contain the characters allowed by the Microsoft Entra username policy
@@ -362,7 +362,7 @@ func (p Provider) VerifyUsername(requestedUsername, authenticatedUsername string
 		return providerErrors.NewForDisplayError("the authenticated username %q contains invalid characters. Please report this error on https://github.com/ubuntu/authd/issues", authenticatedUsername)
 	}
 	if !usernameRegexp.MatchString(requestedUsername) {
-		return fmt.Errorf("requested username %q contains invalid characters", requestedUsername)
+		return providerErrors.NewForDisplayError("requested username %q contains invalid characters", requestedUsername)
 	}
 
 	return nil


### PR DESCRIPTION
When the username which the user tries to log in as doesn't match the username which the user authenticates to via Entra ID / Google IAM, we show the error message:

    authentication failure: could not fetch user info

That's not very helpful. Let's instead show the error message which explains what went wrong:

    requested username X does not match the authenticated user Y

And in case the username contains invalid characters:

    requested username X contains invalid characters