### PR TITLE
Fix UserPreCheck D-Bus interface

### DIFF
--- a/internal/dbusservice/dbusservice.go
+++ b/internal/dbusservice/dbusservice.go
@@ -45,6 +45,7 @@ const intro = `
 		</method>
 		<method name="UserPreCheck">
 			<arg type="s" direction="in" name="username"/>
+			<arg type="s" direction="out" name="userInfo"/>
 		</method>
 	</interface>` + introspect.IntrospectDataString + `</node> `
 


### PR DESCRIPTION
The D-Bus interface definition of the `UserPreCheck` method was missing the out parameter for the user info it returns.