### PR TITLE
Use consistent spelling in broker.conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -30,12 +30,12 @@ client_id = <CLIENT_ID>
 #ssh_allowed_suffixes = @example.com,@anotherexample.com
 
 ## 'allowed_users' specifies the users who are permitted to log in after
-## successfully authenticating with the Identity Provider.
+## successfully authenticating with the identity provider.
 ## Values are separated by commas. Supported values:
 ## - 'OWNER': Grants access to the user specified in the 'owner' option
 ##            (see below). This is the default.
 ## - 'ALL': Grants access to all users who successfully authenticate
-##          with the Identity Provider.
+##          with the identity provider.
 ## - <username>: Grants access to specific additional users
 ##               (e.g. user1@example.com).
 ## Example: allowed_users = OWNER,user1@example.com,admin@example.com


### PR DESCRIPTION
Consistently use the spelling "identity provider" instead of "Identity Provider" in the broker.conf file.