### PR TITLE
msentraid: Do not mention client secret in broker.conf

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -2,10 +2,6 @@
 issuer = https://login.microsoftonline.com/<ISSUER_ID>/v2.0
 client_id = <CLIENT_ID>
 
-## Depending on the identity provider, you may need to provide a
-## client secret to authenticate with the provider.
-#client_secret = <CLIENT_SECRET>
-
 ## Force remote authentication with the identity provider during login,
 ## even if a local method (e.g. local password) is used.
 ## This works by forcing a token refresh during login, which fails if the


### PR DESCRIPTION
Entra applications used for authd-msentraid can't use a client secret (see https://github.com/ubuntu/authd/issues/1005), so we should not document it in the broker.conf file shipped with authd-msentraid, to avoid that users are misled into incorrectly using a client secret.

Closes https://github.com/ubuntu/authd/issues/1005 
UDENG-7295