### PR TITLE
snap: Run `go mod vendor` as part of the broker build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,7 @@ parts:
       - go
     override-build: |
       go mod download all
+      go mod vendor
       go build -tags=withmsentraid -o ${GOBIN}/authd-msentraid ./cmd/authd-oidc
   config:
     source: conf/


### PR DESCRIPTION
I had a snap build fail because I didn't run `go mod vendor` before running `snapcraft build`. That should really be done as part of the snap build.