### PR TITLE
Fix for changing local password

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -605,6 +605,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 			// Store the auth info in the session so that we can use it when handling the
 			// next IsAuthenticated call for the new password mode.
 			session.authInfo = authInfo
+			session.nextAuthModes = []string{authmodes.NewPassword}
 			return AuthNext, nil
 		}
 

--- a/internal/broker/broker_test.go
+++ b/internal/broker/broker_test.go
@@ -472,10 +472,11 @@ func TestIsAuthenticated(t *testing.T) {
 			useOldNameForSecretField: true,
 		},
 		"Authenticating_to_change_password_still_allowed_if_fetching_user_info_fails": {
-			sessionMode:      sessionmode.ChangePassword,
-			firstMode:        authmodes.Password,
-			token:            &tokenOptions{noUserInfo: true},
-			getUserInfoFails: true,
+			sessionMode:       sessionmode.ChangePassword,
+			firstMode:         authmodes.Password,
+			wantNextAuthModes: []string{authmodes.NewPassword},
+			token:             &tokenOptions{noUserInfo: true},
+			getUserInfoFails:  true,
 		},
 		"Authenticating_with_password_when_refresh_token_is_expired_results_in_device_auth_as_next_mode": {
 			firstMode:         authmodes.Password,


### PR DESCRIPTION
After #325, there was a regression where we stopped returning the NewPassword authentication mode as a next step for passwd sessions (to change the local password once it's already defined). This fixes that by returning the expected next authentication mode (i.e. NewPassword).