### PR TITLE
Print a message when the refresh token is expired

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -618,9 +618,9 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 			authInfo, err = b.refreshToken(ctx, session.oauth2Config, authInfo)
 			var retrieveErr *oauth2.RetrieveError
 			if errors.As(err, &retrieveErr) && b.provider.IsTokenExpiredError(*retrieveErr) {
-				// The refresh token is expired, so the user needs to authenticate via OIDC again.
+				log.Noticef(context.Background(), "Refresh token expired for user %q, new device authentication required", session.username)
 				session.nextAuthModes = []string{authmodes.Device, authmodes.DeviceQr}
-				return AuthNext, nil
+				return AuthNext, errorMessage{Message: "refresh token expired, please authenticate again using device authentication"}
 			}
 			if err != nil {
 				log.Error(context.Background(), err.Error())

--- a/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_refresh_token_is_expired_results_in_device_auth_as_next_mode/first_call
+++ b/internal/broker/testdata/golden/TestIsAuthenticated/Authenticating_with_password_when_refresh_token_is_expired_results_in_device_auth_as_next_mode/first_call
@@ -1,3 +1,3 @@
 access: next
-data: '{}'
+data: '{"message":"authentication failure: refresh token expired, please authenticate again using device authentication"}'
 err: <nil>


### PR DESCRIPTION
I encountered the case that the refresh token in one of my VMs was expired and was puzzled for a while why the PAM module auto-selects device authentication after I entered my local password. Let's print a message which makes it clear to the user why device authentication is required.

UDENG-7629