### PR TITLE
Log error when login fails because provider is unreachable

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -610,6 +610,7 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 		}
 
 		if b.cfg.forceProviderAuthentication && session.isOffline {
+			log.Error(context.Background(), "Login failed: force_provider_authentication is enabled, but the provider is not reachable")
 			return AuthDenied, errorMessage{Message: "could not refresh token: provider is not reachable"}
 		}
 


### PR DESCRIPTION
We were not logging an error in that case, making it unclear from the logs why the login failed.

UDENG-7721