### PR TITLE
ci: Use apt-get instead of apt

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -24,8 +24,8 @@ jobs:
         - name: Install dependencies
           run: |
             set -eu
-            sudo apt update
-            sudo apt install -y git
+            sudo apt-get update
+            sudo apt-get install -y git
         - uses: actions/checkout@v5
           with:
             ref: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install dependencies
         run: |
           set -eu
-          sudo apt update
-          sudo apt install -y git-delta
+          sudo apt-get update
+          sudo apt-get install -y git-delta
 
       - name: Install coverage collection dependencies
         run: |


### PR DESCRIPTION
To avoid this warning being printed:

    WARNING: apt does not have a stable CLI interface. Use with caution in scripts.