### PR TITLE
ci: Avoid installing locales and man pages

### DIFF
--- a/.github/workflows/auto-updates.yml
+++ b/.github/workflows/auto-updates.yml
@@ -21,6 +21,7 @@ jobs:
         branch_name: ["google","msentraid"]
     runs-on: ubuntu-latest
     steps:
+        - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
         - name: Install dependencies
           run: |
             set -eu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
       - name: Install dependencies
         run: |
           set -eu


### PR DESCRIPTION
Speed up CI jobs by avoiding installation of locales and man pages.

UDENG-7865