### PR TITLE
Reduce device access token polling interval

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -227,7 +227,6 @@ func (b *Broker) GetAuthenticationModes(sessionID string, supportedUILayouts []m
 
 	for _, mode := range availableModes {
 		if !slices.Contains(modesSupportedByUI, mode) {
-			log.Debugf(context.Background(), "Authentication mode %q is not supported by the UI", mode)
 			continue
 		}
 

--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -542,6 +542,10 @@ func (b *Broker) handleIsAuthenticated(ctx context.Context, session *session, au
 		expiryCtx, cancel := context.WithDeadline(ctx, response.Expiry)
 		defer cancel()
 
+		// The default interval is 5 seconds, which means the user has to wait up to 5 seconds after
+		// successful authentication. We're reducing the interval to 1 second to improve UX a bit.
+		response.Interval = 1
+
 		log.Debug(ctx, "Polling to exchange device code for token...")
 		t, err := session.oauth2Config.DeviceAccessToken(expiryCtx, response, b.provider.AuthOptions()...)
 		if err != nil {

--- a/internal/dbusservice/methods.go
+++ b/internal/dbusservice/methods.go
@@ -10,33 +10,41 @@ import (
 
 // NewSession is the method through which the broker and the daemon will communicate once dbusInterface.NewSession is called.
 func (s *Service) NewSession(username, lang, mode string) (sessionID, encryptionKey string, dbusErr *dbus.Error) {
+	log.Debugf(context.Background(), "Creating new session (username=%s, lang=%s, mode=%s)", username, lang, mode)
 	sessionID, encryptionKey, err := s.broker.NewSession(username, lang, mode)
 	if err != nil {
 		return "", "", dbus.MakeFailedError(err)
 	}
+	log.Debugf(context.Background(), "Created new session %s", sessionID)
 	return sessionID, encryptionKey, nil
 }
 
 // GetAuthenticationModes is the method through which the broker and the daemon will communicate once dbusInterface.GetAuthenticationModes is called.
 func (s *Service) GetAuthenticationModes(sessionID string, supportedUILayouts []map[string]string) (authenticationModes []map[string]string, dbusErr *dbus.Error) {
+	log.Debugf(context.Background(), "Getting authentication modes for session %s", sessionID)
 	authenticationModes, err := s.broker.GetAuthenticationModes(sessionID, supportedUILayouts)
 	if err != nil {
 		return nil, dbus.MakeFailedError(err)
 	}
+	log.Debugf(context.Background(), "Got authentication modes for session %s: %v", sessionID, authenticationModes)
 	return authenticationModes, nil
 }
 
 // SelectAuthenticationMode is the method through which the broker and the daemon will communicate once dbusInterface.SelectAuthenticationMode is called.
 func (s *Service) SelectAuthenticationMode(sessionID, authenticationModeName string) (uiLayoutInfo map[string]string, dbusErr *dbus.Error) {
+	log.Debugf(context.Background(), "Selecting authentication mode %s for session %s", authenticationModeName, sessionID)
 	uiLayoutInfo, err := s.broker.SelectAuthenticationMode(sessionID, authenticationModeName)
 	if err != nil {
 		return nil, dbus.MakeFailedError(err)
 	}
+	log.Debugf(context.Background(), "Selected authentication mode %s for session %s: %v", authenticationModeName, sessionID, uiLayoutInfo)
 	return uiLayoutInfo, nil
 }
 
 // IsAuthenticated is the method through which the broker and the daemon will communicate once dbusInterface.IsAuthenticated is called.
 func (s *Service) IsAuthenticated(sessionID, authenticationData string) (access, data string, dbusErr *dbus.Error) {
+	// Do *not* log authenticationData here, because it may contain the user's password in cleartext.
+	log.Debugf(context.Background(), "Handling IsAuthenticated call for session %s", sessionID)
 	access, data, err := s.broker.IsAuthenticated(sessionID, authenticationData)
 	if errors.Is(err, context.Canceled) {
 		return access, data, makeCanceledError()
@@ -45,12 +53,13 @@ func (s *Service) IsAuthenticated(sessionID, authenticationData string) (access,
 		log.Warningf(context.Background(), "IsAuthenticated error: %v", err)
 		return "", "", dbus.MakeFailedError(err)
 	}
-	log.Debugf(context.Background(), "IsAuthenticated: %s", access)
+	log.Debugf(context.Background(), "IsAuthenticated result (session %s): %s, %s", sessionID, access, data)
 	return access, data, nil
 }
 
 // EndSession is the method through which the broker and the daemon will communicate once dbusInterface.EndSession is called.
 func (s *Service) EndSession(sessionID string) (dbusErr *dbus.Error) {
+	log.Debugf(context.Background(), "Ending session %s", sessionID)
 	err := s.broker.EndSession(sessionID)
 	if err != nil {
 		return dbus.MakeFailedError(err)
@@ -60,16 +69,19 @@ func (s *Service) EndSession(sessionID string) (dbusErr *dbus.Error) {
 
 // CancelIsAuthenticated is the method through which the broker and the daemon will communicate once dbusInterface.CancelIsAuthenticated is called.
 func (s *Service) CancelIsAuthenticated(sessionID string) (dbusErr *dbus.Error) {
+	log.Debugf(context.Background(), "Cancelling IsAuthenticated call for session %s", sessionID)
 	s.broker.CancelIsAuthenticated(sessionID)
 	return nil
 }
 
 // UserPreCheck is the method through which the broker and the daemon will communicate once dbusInterface.UserPreCheck is called.
 func (s *Service) UserPreCheck(username string) (userinfo string, dbusErr *dbus.Error) {
+	log.Debugf(context.Background(), "UserPreCheck: %s", username)
 	userinfo, err := s.broker.UserPreCheck(username)
 	if err != nil {
 		return "", dbus.MakeFailedError(err)
 	}
+	log.Debugf(context.Background(), "UserPreCheck result: %s", userinfo)
 	return userinfo, nil
 }
 

--- a/internal/testutils/provider.go
+++ b/internal/testutils/provider.go
@@ -335,7 +335,7 @@ func ExpiryDeviceAuthHandler() EndpointHandler {
 			"device_code": "device_code",
 			"user_code": "user_code",
 			"verification_uri": "https://verification_uri.com",
-			"expires_in": 4
+			"expires_in": 1
 		}`
 
 		w.Header().Add("Content-Type", "application/json")


### PR DESCRIPTION
The default interval is 5 seconds, which means the user has to wait up to 5 seconds after successful authentication. That's a quite long time to wait. Let's improve UX by reducing the interval to 1 second.

This becomes even more important with device registration, which itself takes about 5 seconds, adding to the time the user has to wait.

UDENG-7907