### PR TITLE
Bump Go toolchain version to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers
 
 go 1.24.0
 
-toolchain go1.24.4
+toolchain go1.24.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1


### PR DESCRIPTION
govulncheck reports the following vulnerability in go1.24.4

```
Vulnerability #1: GO-2025-3956
    Unexpected paths returned from LookPath in os/exec
  More info: https://pkg.go.dev/vuln/GO-2025-3956
  Standard library
    Found in: os/exec@go1.24.4
    Fixed in: os/exec@go1.24.6
    Example traces found:
Error:       #1: internal/testutils/dbus.go:59:28: testutils.StartSystemBusMock calls exec.CommandContext, which eventually calls exec.LookPath
```