### PR TITLE
Make the broker service D-Bus activated

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,12 +11,13 @@ license: GPL-3.0
 apps:
   authd-oidc:
     command: bin/authd-oidc
-    daemon: simple
+    daemon: dbus
     slots:
       - dbus-authd
     plugs:
       - network
     restart-condition: always
+    activates-on: [dbus-authd]
 
 slots:
   dbus-authd:


### PR DESCRIPTION
This has the effect that both after installation and during boot, the broker service is not started automatically but only the first time a user tries to authenticate via PAM.

For now there are a few small benefits:
* Currently, the service always fails to start after installation, because the user didn't have a chance to replace the placeholders in the configuration file yet. That results in errors in the system log, which is a bit unclean.
* In the case that the system is useful after boot without a user logging in (so usually when it's a server), we avoid using up resources for a service that's not needed - at least until the first user tries to log in.
* In case a broker was installed but authd was not configured to use it, that broker is not started anymore.

Having the system D-Bus activated will become even more useful if we at some point make it exit on idle, because then we can free up its resources (primarily the memory) after some time.

Closes ubuntu/authd#1101