### PR TITLE
Add comment about updating security overview doc

### DIFF
--- a/internal/password/password.go
+++ b/internal/password/password.go
@@ -54,5 +54,6 @@ func CheckPassword(password, path string) (bool, error) {
 }
 
 func hashPassword(password string, salt []byte) []byte {
+	// If you change these parameters, update the section in the security overview doc.
 	return argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32)
 }


### PR DESCRIPTION
We're adding a security overview documentation to authd which includes a section about how hash the local password.

This adds a code comment to remind us to keep that section up to date.