### PR TITLE
Show a nice error message when user is disabled

### DIFF
--- a/internal/broker/broker.go
+++ b/internal/broker/broker.go
@@ -743,12 +743,12 @@ func (b *Broker) passwordAuth(ctx context.Context, session *session, secret stri
 		authInfo, err = b.refreshToken(ctx, session, authInfo)
 		var retrieveErr *oauth2.RetrieveError
 		if errors.As(err, &retrieveErr) {
-			if b.provider.IsTokenExpiredError(*retrieveErr) {
+			if b.provider.IsTokenExpiredError(retrieveErr) {
 				log.Noticef(context.Background(), "Refresh token expired for user %q, new device authentication required", session.username)
 				session.nextAuthModes = []string{authmodes.Device, authmodes.DeviceQr}
 				return AuthNext, errorMessage{Message: "Refresh token expired, please authenticate again using device authentication."}
 			}
-			if b.provider.IsUserDisabledError(*retrieveErr) {
+			if b.provider.IsUserDisabledError(retrieveErr) {
 				log.Error(context.Background(), retrieveErr.Error())
 				log.Errorf(context.Background(), "Login failed: User %q is disabled in Microsoft Entra ID, please contact your administrator.", session.username)
 				return AuthDenied, errorMessage{Message: "This user is disabled in Microsoft Entra ID, please contact your administrator."}

--- a/internal/providers/genericprovider/genericprovider.go
+++ b/internal/providers/genericprovider/genericprovider.go
@@ -100,14 +100,14 @@ func (p GenericProvider) userClaims(idToken info.Claimer) (claims, error) {
 }
 
 // IsTokenExpiredError returns true if the reason for the error is that the refresh token is expired.
-func (p GenericProvider) IsTokenExpiredError(err oauth2.RetrieveError) bool {
+func (p GenericProvider) IsTokenExpiredError(err *oauth2.RetrieveError) bool {
 	// TODO: This is an msentraid specific error code and description.
 	//       Change it to the ones from Google once we know them.
 	return err.ErrorCode == "invalid_grant" && strings.HasPrefix(err.ErrorDescription, "AADSTS50173:")
 }
 
 // IsUserDisabledError returns false, as the generic provider does not support disabling users.
-func (p GenericProvider) IsUserDisabledError(_ oauth2.RetrieveError) bool {
+func (p GenericProvider) IsUserDisabledError(_ *oauth2.RetrieveError) bool {
 	return false
 }
 

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -530,11 +530,11 @@ func (c azureTokenCredential) GetToken(_ context.Context, _ policy.TokenRequestO
 }
 
 // IsTokenExpiredError returns true if the reason for the error is that the refresh token is expired.
-func (p *Provider) IsTokenExpiredError(err oauth2.RetrieveError) bool {
+func (p *Provider) IsTokenExpiredError(err *oauth2.RetrieveError) bool {
 	return err.ErrorCode == "invalid_grant" && strings.HasPrefix(err.ErrorDescription, "AADSTS50173:")
 }
 
 // IsUserDisabledError returns true if the reason for the error is that the user is disabled.
-func (p *Provider) IsUserDisabledError(err oauth2.RetrieveError) bool {
+func (p *Provider) IsUserDisabledError(err *oauth2.RetrieveError) bool {
 	return err.ErrorCode == "invalid_grant" && strings.HasPrefix(err.ErrorDescription, "AADSTS50057:")
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -27,8 +27,8 @@ type Provider interface {
 		deviceRegistrationData []byte,
 	) ([]info.Group, error)
 
-	IsTokenExpiredError(err oauth2.RetrieveError) bool
-	IsUserDisabledError(err oauth2.RetrieveError) bool
+	IsTokenExpiredError(err *oauth2.RetrieveError) bool
+	IsUserDisabledError(err *oauth2.RetrieveError) bool
 	IsTokenForDeviceRegistration(token *oauth2.Token) (bool, error)
 
 	MaybeRegisterDevice(


### PR DESCRIPTION
The message shown to the user used to be:

    Failed to refresh token

Now it's:

    This user is disabled in Microsoft Entra ID, please contact your administrator.

> [!IMPORTANT]
> ~~This is based on https://github.com/ubuntu/authd-oidc-brokers/pull/585, please review and merge after that.~~
