### PR TITLE
Fix code navigation

### DIFF
--- a/e2e-tests/resources/authd-msentraid/broker.resource
+++ b/e2e-tests/resources/authd-msentraid/broker.resource
@@ -2,13 +2,12 @@
 Documentation       MS Entra ID specific resources for the tests
 
 Resource            kvm.resource
-Resource            ${AUTHD_RESOURCES}/utils.resource
+Resource            ../authd/utils.resource
 
 Library            Process
 
 *** Variables ***
-${AUTHD_RESOURCES}    ${CURDIR}/../authd-resources
-${ENTRAID_RESOURCES}    ${CURDIR}/../broker-resources
+${ENTRAID_RESOURCES}    ${CURDIR}
 
 ${AUTHD_BROKER_CFG}    /etc/authd/brokers.d/msentraid.conf
 ${ENTRAID_BROKER_CFG}    /var/snap/authd-msentraid/current/broker.conf

--- a/e2e-tests/resources/authd/authd.resource
+++ b/e2e-tests/resources/authd/authd.resource
@@ -2,11 +2,10 @@
 Documentation       Authd related test resources
 
 Resource            kvm.resource
-Resource            ${AUTHD_RESOURCES}/utils.resource
+Resource            ./utils.resource
 
 
 *** Variables ***
-${AUTHD_RESOURCES}    ${CURDIR}/../authd-resources
 ${local_password}    qwer1234
 
 

--- a/e2e-tests/resources/broker
+++ b/e2e-tests/resources/broker
@@ -1,0 +1,1 @@
+authd-msentraid

--- a/e2e-tests/tests/authd_disabled.robot
+++ b/e2e-tests/tests/authd_disabled.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 
 

--- a/e2e-tests/tests/block_login_with_different_username.robot
+++ b/e2e-tests/tests/block_login_with_different_username.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/broker_disabled.robot
+++ b/e2e-tests/tests/broker_disabled.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 
 

--- a/e2e-tests/tests/config_issuer_invalid.robot
+++ b/e2e-tests/tests/config_issuer_invalid.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 

--- a/e2e-tests/tests/config_owner_empty.robot
+++ b/e2e-tests/tests/config_owner_empty.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 

--- a/e2e-tests/tests/config_owner_unset.robot
+++ b/e2e-tests/tests/config_owner_unset.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 

--- a/e2e-tests/tests/deny_login_if_user_not_allowed.robot
+++ b/e2e-tests/tests/deny_login_if_user_not_allowed.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    another-%{E2E_USER}
 
 

--- a/e2e-tests/tests/login.robot
+++ b/e2e-tests/tests/login.robot
@@ -1,16 +1,12 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
-
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/login_gdm.robot
+++ b/e2e-tests/tests/login_gdm.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/migration_authd.robot
+++ b/e2e-tests/tests/migration_authd.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/migration_authd_broker.robot
+++ b/e2e-tests/tests/migration_authd_broker.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/migration_broker.robot
+++ b/e2e-tests/tests/migration_broker.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/mixed_case_username.robot
+++ b/e2e-tests/tests/mixed_case_username.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/password_change.robot
+++ b/e2e-tests/tests/password_change.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${new_password}    passwd1234

--- a/e2e-tests/tests/regenerate_qrcode.robot
+++ b/e2e-tests/tests/regenerate_qrcode.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/resources
+++ b/e2e-tests/tests/resources
@@ -1,0 +1,1 @@
+../resources

--- a/e2e-tests/tests/ssh_deny_login_if_prefix_not_allowed.robot
+++ b/e2e-tests/tests/ssh_deny_login_if_prefix_not_allowed.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    another-%{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group

--- a/e2e-tests/tests/ssh_login.robot
+++ b/e2e-tests/tests/ssh_login.robot
@@ -1,16 +1,13 @@
 *** Settings ***
-Resource        ${AUTHD_RESOURCES_DIR}/utils.resource
-Resource        ${AUTHD_RESOURCES_DIR}/authd.resource
+Resource        ./resources/authd/utils.resource
+Resource        ./resources/authd/authd.resource
 
-Resource        ${BROKER_RESOURCES_DIR}/broker.resource
+Resource        ./resources/broker/broker.resource
 
 Test Tags       robot:exit-on-failure
 
 
 *** Variables ***
-${AUTHD_RESOURCES_DIR}        ${CURDIR}/authd-resources
-${BROKER_RESOURCES_DIR}      ${CURDIR}/broker-resources
-
 ${username}    %{E2E_USER}
 ${local_password}    qwer1234
 ${remote_group}    %{E2E_USER}-group


### PR DESCRIPTION
Create a symlink e2e-tests/resources/broker which points to the broker implementation that's used by the tests and is updated by run_tests.sh.

It's not perfect because code navigation will always navigate to the broker implementation which was last used in tests, but it's way better than no code navigation at all.