### PR TITLE
msentraid: Use the value of the "name" claim from the ID token as gecos

### DIFF
--- a/internal/providers/msentraid/helper_test.go
+++ b/internal/providers/msentraid/helper_test.go
@@ -10,7 +10,7 @@ var (
 		"sub": "valid-sub",
 		"home": "/home/valid-user",
 		"shell": "/bin/bash",
-		"gecos": "Valid User"}`,
+		"name": "Valid User"}`,
 	}
 
 	invalidIDToken = &testIDToken{

--- a/internal/providers/msentraid/msentraid.go
+++ b/internal/providers/msentraid/msentraid.go
@@ -191,7 +191,7 @@ type claims struct {
 	Sub               string `json:"sub"`
 	Home              string `json:"home"`
 	Shell             string `json:"shell"`
-	Gecos             string `json:"gecos"`
+	Gecos             string `json:"name"`
 }
 
 // userClaims returns the user claims parsed from the ID token.


### PR DESCRIPTION
The "name" claim of the ID token returned by Entra contains the display name of the account. Using that for gecos has the effect e.g. on the login screen, the display name is shown to the user instead of the UPN.

Closes ubuntu/authd#1107
UDENG-8444