### PR TITLE
Fix "Run tests (with coverage collection)" ignoring test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Run tests (with coverage collection)
         if: matrix.test == 'coverage'
         run: |
-          set -eu
+          set -euo pipefail
 
           # The coverage is not written if the output directory does not exist, so we need to create it.
           cov_dir=${PWD}/coverage


### PR DESCRIPTION
We pipe the output of the tests to gotestfmt, so we need `-o pipefail` to make the job fail if the tests fail.