### PR TITLE
ci: Automatically cancel in-progress workflow runs on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - "*"
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   go-sanity:
     name: "Go: Code sanity"


### PR DESCRIPTION
Our CI jobs run for a long time and use a lot of resources.

It happens quite often to me that, after I push something to a PR, I find something to small to fix (e.g. improve the commit message) and push that fix soon after. We can save some resources by automatically cancelling in-progress workflows on new pushes to the same branch (I do that manually sometimes, but that's wasting my time).

The implementation is directly from the example of the concurrency keyword: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-concurrency-and-the-default-behavior

UDENG-8268