### PR TITLE
Bump Go toolchain version to 1.24.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers
 
 go 1.24.0
 
-toolchain go1.24.6
+toolchain go1.24.9
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers/tools
 
 go 1.24.0
 
-toolchain go1.24.1
+toolchain go1.24.9
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.5.0


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.24.6

```
Vulnerability #1: GO-2025-4013
    Panic when validating certificates with DSA public keys in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4013
  Standard library
    Found in: crypto/x509@go1.24.6
    Fixed in: crypto/x509@go1.24.8
    Example traces found:
Error:       #1: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.Verify

Vulnerability #2: GO-2025-4012
    Lack of limit when parsing cookies can cause memory exhaustion in net/http
  More info: https://pkg.go.dev/vuln/GO-2025-4012
  Standard library
    Found in: net/http@go1.24.6
    Fixed in: net/http@go1.24.8
    Example traces found:
Error:       #1: internal/broker/broker.go:471:51: broker.Broker.generateUILayout calls oauth2.Config.DeviceAuth, which eventually calls http.Client.Do

Vulnerability #3: GO-2025-4011
    Parsing DER payload can cause memory exhaustion in encoding/asn1
  More info: https://pkg.go.dev/vuln/GO-2025-4011
  Standard library
    Found in: encoding/asn1@go1.24.6
    Fixed in: encoding/asn1@go1.24.8
    Example traces found:
Error:       #1: internal/testutils/provider.go:68:36: testutils.init#1 calls x509.ParseCertificate, which eventually calls asn1.Unmarshal

Vulnerability #4: GO-2025-4010
    Insufficient validation of bracketed IPv6 hostnames in net/url
  More info: https://pkg.go.dev/vuln/GO-2025-4010
  Standard library
    Found in: net/url@go1.24.6
    Fixed in: net/url@go1.24.8
    Example traces found:
Error:       #1: internal/providers/msentraid/himmelblau/himmelblau.go:68:33: himmelblau.ensureBrokerClientAppInitialized calls url.JoinPath
Error:       #2: internal/broker/broker.go:216:25: broker.Broker.connectToOIDCServer calls oidc.NewProvider, which eventually calls url.Parse
Error:       #3: internal/testutils/provider.go:104:14: testutils.StartMockProviderServer calls httptest.Server.Start, which eventually calls url.ParseRequestURI
Error:       #4: internal/broker/broker.go:471:51: broker.Broker.generateUILayout calls oauth2.Config.DeviceAuth, which eventually calls url.URL.Parse

Vulnerability #5: GO-2025-4009
    Quadratic complexity when parsing some invalid inputs in encoding/pem
  More info: https://pkg.go.dev/vuln/GO-2025-4009
  Standard library
    Found in: encoding/pem@go1.24.6
    Fixed in: encoding/pem@go1.24.8
    Example traces found:
Error:       #1: internal/providers/msentraid/himmelblau/himmelblau.go:66:28: himmelblau.ensureBrokerClientAppInitialized calls sync.Once.Do, which eventually calls pem.Decode

Vulnerability #6: GO-2025-4008
    ALPN negotiation error contains attacker controlled information in
    crypto/tls
  More info: https://pkg.go.dev/vuln/GO-2025-4008
  Standard library
    Found in: crypto/tls@go1.24.6
    Fixed in: crypto/tls@go1.24.8
    Example traces found:
Error:       #1: internal/testutils/provider.go:104:14: testutils.StartMockProviderServer calls httptest.Server.Start, which eventually calls tls.Conn.HandshakeContext
Error:       #2: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls tls.Conn.Read
Error:       #3: cmd/authd-oidc/daemon/daemon_test.go:399:14: daemon_test.TestMain calls fmt.Fprintf, which calls tls.Conn.Write
Error:       #4: internal/broker/broker.go:471:51: broker.Broker.generateUILayout calls oauth2.Config.DeviceAuth, which eventually calls tls.Dialer.DialContext

Vulnerability #7: GO-2025-4007
    Quadratic complexity when checking name constraints in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4007
  Standard library
    Found in: crypto/x509@go1.24.6
    Fixed in: crypto/x509@go1.24.9
    Example traces found:
Error:       #1: internal/providers/msentraid/himmelblau/himmelblau.go:66:28: himmelblau.ensureBrokerClientAppInitialized calls sync.Once.Do, which eventually calls x509.CertPool.AppendCertsFromPEM
Error:       #2: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.Verify
Error:       #3: internal/testutils/provider.go:63:34: testutils.init#1 calls x509.CreateCertificate
Error:       #4: internal/broker/broker.go:170:43: broker.Broker.NewSession calls x509.MarshalPKIXPublicKey
Error:       #5: internal/testutils/provider.go:68:36: testutils.init#1 calls x509.ParseCertificate
Error:       #6: internal/providers/msentraid/msmock_test.go:331:42: msentraid_test.mockMSServer.handleDeviceEnrollmentRequest calls x509.ParseCertificateRequest
Error:       #7: internal/broker/helper_test.go:159:40: broker_test.encryptSecret calls x509.ParsePKIXPublicKey
```