### PR TITLE
docs: fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ This is the code repository for authd OpenID Connect (OIDC) brokers. It is used 
 
 This project contains specific code for different OpenID Connect providers. We build one binary for each and snap them based on build tags to integrate with the Ubuntu authentication daemon.
 
-For general details, check the authd [getting started guide](https://github.com/ubuntu/authd/wiki/01---Get-started-with-authd). The same documentation reference hosts [installation](https://github.com/ubuntu/authd/wiki/02---Installation) and [configuration](https://github.com/ubuntu/authd/wiki/03---Configuration) instructions.
+For general details, read the [authd documentation](https://documentation.ubuntu.com/authd/stable-docs/).
+
+The documentation includes details on [installing](https://documentation.ubuntu.com/authd/stable-docs/howto/install-authd/) and [configuring](https://documentation.ubuntu.com/authd/stable-docs/howto/configure-authd/) authd.
 
 ## Troubleshooting
 
-More details on troubleshooting one of the OIDC brokers is available on the [authd documentation](https://github.com/ubuntu/authd/wiki/05--Troubleshooting).
+More details on troubleshooting one authd and authd brokers is available in the [authd documentation](https://documentation.ubuntu.com/authd/stable-docs/reference/troubleshooting/).
 
 ## Get involved
 


### PR DESCRIPTION
The README contains broken badges...

Old badges:

<img width="472" height="29" alt="image" src="https://github.com/user-attachments/assets/b986dd96-5203-4c0f-81a1-e921bdb0a959" />

New:

<img width="495" height="29" alt="image" src="https://github.com/user-attachments/assets/98ba4938-09a8-4a6e-bf00-a0d4bff755ed" />

---

The README also had links to the obsolete authd wiki, which I replaced with links to the authd docs.
