### PR TITLE
Bump Go toolchain version to 1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,7 +2,7 @@ module github.com/ubuntu/authd-oidc-brokers/tools
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.11
 
 require (
 	github.com/golangci/golangci-lint/v2 v2.6.2


### PR DESCRIPTION
govulncheck reports the following vulnerabilities in go1.24.9

```
Vulnerability #1: GO-2025-4175
    Improper application of excluded DNS name constraints when verifying
    wildcard names in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4175
  Standard library
    Found in: crypto/x509@go1.24.9
    Fixed in: crypto/x509@go1.24.11
    Example traces found:
Error:       #1: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.Verify

Vulnerability #2: GO-2025-4155
    Excessive resource consumption when printing error string for host
    certificate validation in crypto/x509
  More info: https://pkg.go.dev/vuln/GO-2025-4155
  Standard library
    Found in: crypto/x509@go1.24.9
    Fixed in: crypto/x509@go1.24.11
    Example traces found:
Error:       #1: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.Verify
Error:       #2: cmd/authd-oidc/daemon/daemon_test.go:211:18: daemon_test.TestAppCanSigHupWithoutExecute calls io.Copy, which eventually calls x509.Certificate.VerifyHostname
```