### PR TITLE
e2e-tests: Export journal via VSOCK on questing

### DIFF
--- a/e2e-tests/vm/cloud-init-template-questing.yaml
+++ b/e2e-tests/vm/cloud-init-template-questing.yaml
@@ -65,6 +65,12 @@ write_files:
       Match User *@*
           KbdInteractiveAuthentication yes
 
+    # Export the journal via VSOCK
+  - path: /etc/systemd/journald.conf.d/00-forward-to-vsock.conf
+    content: |
+      [Journal]
+      ForwardToSocket=vsock:2:52000
+
 runcmd:
   # Disable apport
   - sed -i 's/enabled=1/enabled=0/' /etc/default/apport


### PR DESCRIPTION
We don't need journal-vsock-export there because systemd v256 has built-in support to forward journal messages via VSOCK.